### PR TITLE
Fix/gh apipeline

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -24,7 +24,7 @@
 on: 
   push:
     branches:
-      - fix/GHApipeline
+      - main
 
 env:
   PFX_CERTIFICATE_BASE64: ${{ secrets.PFX_CERTIFICATE_BASE64 }} # base64 encoded

--- a/exporters/githubactions/exporter.yml
+++ b/exporters/githubactions/exporter.yml
@@ -1,7 +1,7 @@
 # name of the exporter, should mach with the folder name
 name: githubactions
 # version of the package created
-version: 1.2.2
+version: 1.2.0
 # URL to the git project hosting the exporter
 exporter_repo_url: https://github.com/Spendesk/github-actions-exporter
 # Tag of the exporter to checkout


### PR DESCRIPTION
This fixes a weird issue happening during the pipeline workflow

Basically due to the filname exceeding 256 chars the pipeline was failing. There is not a "real" fix, only using a smaller path

Tested creating a release in a branch 

 - https://github.com/newrelic/newrelic-prometheus-exporters-packages/releases/tag/githubactions-1.2.2