### PR TITLE
fix: remove integration parameter from config

### DIFF
--- a/exporters/github/github-exporter-windows.yml.sample
+++ b/exporters/github/github-exporter-windows.yml.sample
@@ -8,10 +8,7 @@ integrations:
     - name: ravendb
       exec: C:\Program Files\Prometheus-exporters\bin\github-exporter.exe
       timeout: 0
-      integration: false
       env:
-        # Github API URL, shouldn't need to change this
-        # API_URL: https://api.github.com
         # If supplied, the exporter will enumerate all repositories for that organization. Expected in the format "org1, org2"
         # ORGS:
         # If supplied, The repos you wish to monitor, expected in the format "user/repo1, user/repo2". Can be across different Github users/orgs
@@ -22,6 +19,8 @@ integrations:
         # GITHUB_TOKEN:
         # If supplied instead of GITHUB_TOKEN, enables the user to supply a path to a file containing a github authentication token that allows the API to be queried more often. Optional, but recommended
         # GITHUB_TOKEN_FILE:
+        # Github API URL, shouldn't need to change this
+        # API_URL: https://api.github.com
         # The port you wish to run the exporter on
         LISTEN_PORT: 9171
         # The metrics URL path you wish to use

--- a/exporters/github/github-exporter.yml.sample
+++ b/exporters/github/github-exporter.yml.sample
@@ -4,14 +4,11 @@ integrations:
         standalone: false
         targets:
           - description: "github"
-             urls: ["http://localhost:9171"]
+            urls: ["http://localhost:9171"]
     - name: ravendb
-       exec: /usr/local/prometheus-exporters/bin/github-exporter
+      exec: /usr/local/prometheus-exporters/bin/github-exporter
       timeout: 0
-      integration: false
       env:
-        # Github API URL, shouldn't need to change this
-        # API_URL: https://api.github.com
         # If supplied, the exporter will enumerate all repositories for that organization. Expected in the format "org1, org2"
         # ORGS:
         # If supplied, The repos you wish to monitor, expected in the format "user/repo1, user/repo2". Can be across different Github users/orgs
@@ -22,6 +19,8 @@ integrations:
         # GITHUB_TOKEN:
         # If supplied instead of GITHUB_TOKEN, enables the user to supply a path to a file containing a github authentication token that allows the API to be queried more often. Optional, but recommended
         # GITHUB_TOKEN_FILE:
+        # Github API URL, shouldn't need to change this
+        # API_URL: https://api.github.com
         # The port you wish to run the exporter on
         LISTEN_PORT: 9171
         # The metrics URL path you wish to use


### PR DESCRIPTION
removes unused parameter from config files and moves more used conifgurations to the top