### PR TITLE
feat(metadata): added integration metadata to prometheus config

### DIFF
--- a/nri-config-generator/main.go
+++ b/nri-config-generator/main.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	varIntegrationName      = "integration"
+	varIntegrationVersion   = "integration_version"
 	varExporterPort         = "exporter_port"
 	varSynthesisDefinitions = "entity_definitions"
 	varExporterDefinition   = "exporter_definition"
@@ -35,12 +36,14 @@ var (
 	configTemplateContent string
 	//go:embed definitions
 	definitions embed.FS
-	vars        = map[string]interface{}{
-		varIntegrationName: integration,
-	}
 )
 
 func main() {
+	vars := map[string]interface{}{
+		varIntegrationName:    integration,
+		varIntegrationVersion: integrationVersion,
+	}
+
 	al, err := args.PopulateVars(vars)
 	panicErr(err)
 	if al.ShowVersion {
@@ -56,7 +59,7 @@ func main() {
 	configTemplate, err := loadConfigTemplate()
 	panicErr(err)
 	configGenerator := generator.NewConfig(configTemplate)
-	port, err := findExporterPort()
+	port, err := findExporterPort(vars)
 	panicErr(err)
 	definitionContent, err := definitions.ReadFile(definitionFileName)
 	panicErr(err)
@@ -103,7 +106,7 @@ func printVersion() {
 		buildDate)
 }
 
-func findExporterPort() (int, error) {
+func findExporterPort(vars map[string]interface{}) (int, error) {
 	cfgPort := ""
 	if cfg, ok := vars[args.PrefixCfg]; ok {
 		cfgVars := cfg.(map[string]interface{})

--- a/nri-config-generator/templates/config.json.tmpl
+++ b/nri-config-generator/templates/config.json.tmpl
@@ -12,6 +12,10 @@
                 "standalone": false,
                 {{set "verbose" .env.VERBOSE}}
                 {{.entity_definitions}},
+                "integration_metadata":{
+                    "version": "{{.integration_version}}",
+                    "name": "{{.integration}}"
+                },
                 "targets": [
                     {
                         "urls": [
@@ -19,7 +23,6 @@
                         ]
                     }
                 ]
-
             }
         },
         {{.exporter_definition}}

--- a/nri-config-generator/tests/generator_test.go
+++ b/nri-config-generator/tests/generator_test.go
@@ -18,8 +18,9 @@ import (
 )
 
 const (
-	testIntegration = "powerdns"
-	exporterPort    = "9120"
+	testIntegrationVersion = "test-tag"
+	testIntegration        = "powerdns"
+	exporterPort           = "9120"
 )
 
 const configPDNSTemplate = `
@@ -36,6 +37,10 @@ const configPDNSTemplate = `
         "config": {
           "standalone": false,
          {{ or .pomiVerbose "" }}
+		  "integration_metadata":{
+			"name": "powerdns",
+			"version": "test-tag"
+		  },
           "entity_definitions": [
 			{
 				"conditions": [{
@@ -100,7 +105,7 @@ func TestMain(m *testing.M) {
 	if err := fetchDefinitions(testIntegration); err != nil {
 		panic(err.Error())
 	}
-	if err := buildGeneratorConfig(testIntegration); err != nil {
+	if err := buildGeneratorConfig(testIntegration, testIntegrationVersion); err != nil {
 		panic(err.Error())
 	}
 	exitVal := m.Run()

--- a/nri-config-generator/tests/generator_test.go
+++ b/nri-config-generator/tests/generator_test.go
@@ -37,10 +37,10 @@ const configPDNSTemplate = `
         "config": {
           "standalone": false,
          {{ or .pomiVerbose "" }}
-		  "integration_metadata":{
-			"name": "powerdns",
-			"version": "test-tag"
-		  },
+          "integration_metadata":{
+            "name": "powerdns",
+            "version": "test-tag"
+          },
           "entity_definitions": [
 			{
 				"conditions": [{

--- a/nri-config-generator/tests/helper.go
+++ b/nri-config-generator/tests/helper.go
@@ -40,7 +40,7 @@ func copyIntegrationTemplate(integration string) error {
 	targetPath := filepath.Join(rootDir(), "templates", fileName)
 	return ioutil.WriteFile(targetPath, bytesRead, 0755)
 }
-func buildGeneratorConfig(integration string) error {
+func buildGeneratorConfig(integration string, integrationVersion string) error {
 	if err := copyIntegrationTemplate(integration); err != nil {
 		return err
 	}
@@ -50,6 +50,7 @@ func buildGeneratorConfig(integration string) error {
 			"make",
 			"compile",
 			fmt.Sprintf("PACKAGE_NAME=%s", integration),
+			fmt.Sprintf("VERSION=%s", integrationVersion),
 		},
 		Dir: rootDir(),
 	}


### PR DESCRIPTION
The objective of this PR is to pass to nri-prometheus the integration metadata so that when querying the data we can track down the integration and exporter version that generated the data

![Screen Shot 2021-07-07 at 3 46 37 PM](https://user-images.githubusercontent.com/43335750/124770306-8527b000-df3a-11eb-80fe-d2aeef8fcde4.png)

 Depends on https://github.com/newrelic/nri-prometheus/pull/210
 
 Fix https://github.com/newrelic/newrelic-coreint/issues/115