### PR TITLE
NR-52118 chore: create spec file

### DIFF
--- a/exporters/mongodb/e2e/mongodb.yml
+++ b/exporters/mongodb/e2e/mongodb.yml
@@ -4876,7 +4876,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_abortTransaction_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -4889,7 +4889,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_abortTransaction_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -4902,7 +4902,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_addShard_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -4915,7 +4915,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_addShard_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -4941,7 +4941,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_aggregate_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -4954,7 +4954,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_aggregate_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -4967,7 +4967,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_appendOplogNote_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -4980,7 +4980,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_appendOplogNote_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -4993,7 +4993,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_applyOps_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5006,7 +5006,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_applyOps_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5019,7 +5019,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_authenticate_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5032,7 +5032,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_authenticate_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5045,7 +5045,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_autoSplitVector_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5058,7 +5058,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_autoSplitVector_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5071,7 +5071,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_availableQueryOptions_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5084,7 +5084,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_availableQueryOptions_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5097,7 +5097,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_buildInfo_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5110,7 +5110,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_buildInfo_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5123,7 +5123,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_checkShardingIndex_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5136,7 +5136,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_checkShardingIndex_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5149,7 +5149,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_cleanupOrphaned_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5162,7 +5162,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_cleanupOrphaned_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5175,7 +5175,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_cloneCatalogData_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5188,7 +5188,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_cloneCatalogData_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5201,7 +5201,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_cloneCollectionAsCapped_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5214,7 +5214,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_cloneCollectionAsCapped_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5227,7 +5227,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_cloneCollectionOptionsFromPrimaryShard_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5240,7 +5240,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_cloneCollectionOptionsFromPrimaryShard_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5253,7 +5253,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_cloneCollection_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5266,7 +5266,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_cloneCollection_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5279,7 +5279,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_collMod_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5292,7 +5292,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_collMod_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5305,7 +5305,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_collStats_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5318,7 +5318,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_collStats_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5331,7 +5331,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_commitTransaction_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5344,7 +5344,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_commitTransaction_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5357,7 +5357,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_compact_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5370,7 +5370,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_compact_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5383,7 +5383,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrAddShardToZone_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5396,7 +5396,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrAddShardToZone_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5409,7 +5409,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrAddShard_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5422,7 +5422,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrAddShard_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5435,7 +5435,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_configsvrBalancerStart_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5448,7 +5448,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrBalancerStart_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5461,7 +5461,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_configsvrBalancerStatus_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5474,7 +5474,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrBalancerStatus_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5487,7 +5487,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_configsvrBalancerStop_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5500,7 +5500,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_configsvrBalancerStop_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5513,7 +5513,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrClearJumboFlag_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5526,7 +5526,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrClearJumboFlag_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5539,7 +5539,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCommitChunkMerge_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5552,7 +5552,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCommitChunkMerge_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5565,7 +5565,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCommitChunkMigration_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5578,7 +5578,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCommitChunkMigration_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5591,7 +5591,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCommitChunkSplit_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5604,7 +5604,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCommitChunkSplit_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5617,7 +5617,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCommitChunksMerge_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5630,7 +5630,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCommitChunksMerge_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5643,7 +5643,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCommitMovePrimary_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5656,7 +5656,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCommitMovePrimary_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5669,7 +5669,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCreateCollection_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5682,7 +5682,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCreateCollection_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5695,7 +5695,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCreateDatabase_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5708,7 +5708,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCreateDatabase_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5721,7 +5721,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrDropCollection_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5734,7 +5734,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_configsvrDropCollection_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5747,7 +5747,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrDropDatabase_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5760,7 +5760,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrDropDatabase_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5773,7 +5773,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_configsvrEnableSharding_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5786,7 +5786,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrEnableSharding_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5799,7 +5799,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_configsvrMoveChunk_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5812,7 +5812,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrMoveChunk_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5825,7 +5825,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_configsvrMovePrimary_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5838,7 +5838,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrMovePrimary_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5851,7 +5851,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrRemoveShardFromZone_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5864,7 +5864,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrRemoveShardFromZone_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5877,7 +5877,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrRemoveShard_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5890,7 +5890,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_configsvrRemoveShard_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5903,7 +5903,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrRepairShardedCollectionChunksHistory_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5916,7 +5916,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrRepairShardedCollectionChunksHistory_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5929,7 +5929,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrShardCollection_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5942,7 +5942,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_configsvrShardCollection_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5955,7 +5955,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_configsvrUpdateZoneKeyRange_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5968,7 +5968,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrUpdateZoneKeyRange_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5981,7 +5981,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_connPoolStats_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5994,7 +5994,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_connPoolStats_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6007,7 +6007,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_connPoolSync_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6020,7 +6020,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_connPoolSync_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6033,7 +6033,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_connectionStatus_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6046,7 +6046,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_connectionStatus_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6059,7 +6059,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_convertToCapped_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6072,7 +6072,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_convertToCapped_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6085,7 +6085,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_coordinateCommitTransaction_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6098,7 +6098,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_coordinateCommitTransaction_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6111,7 +6111,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_count_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6124,7 +6124,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_count_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6137,7 +6137,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_createIndexes_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6150,7 +6150,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_createIndexes_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6163,7 +6163,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_createRole_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6176,7 +6176,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_createRole_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6189,7 +6189,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_createUser_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6202,7 +6202,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_createUser_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6215,7 +6215,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_create_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6228,7 +6228,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_create_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6241,7 +6241,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_currentOp_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6254,7 +6254,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_currentOp_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6267,7 +6267,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_dataSize_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6280,7 +6280,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_dataSize_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6293,7 +6293,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_dbHash_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6306,7 +6306,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_dbHash_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6319,7 +6319,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_dbStats_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6332,7 +6332,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_dbStats_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6345,7 +6345,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_delete_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6358,7 +6358,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_delete_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6371,7 +6371,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_distinct_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6384,7 +6384,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_distinct_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6397,7 +6397,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_driverOIDTest_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6410,7 +6410,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_driverOIDTest_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6423,7 +6423,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_dropAllRolesFromDatabase_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6436,7 +6436,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_dropAllRolesFromDatabase_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6449,7 +6449,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_dropAllUsersFromDatabase_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6462,7 +6462,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_dropAllUsersFromDatabase_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6475,7 +6475,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_dropConnections_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6488,7 +6488,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_dropConnections_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6501,7 +6501,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_dropDatabase_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6514,7 +6514,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_dropDatabase_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6527,7 +6527,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_dropIndexes_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6540,7 +6540,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_dropIndexes_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6553,7 +6553,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_dropRole_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6566,7 +6566,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_dropRole_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6579,7 +6579,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_dropUser_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6592,7 +6592,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_dropUser_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6605,7 +6605,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_drop_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6618,7 +6618,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_drop_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6631,7 +6631,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_endSessions_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6644,7 +6644,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_endSessions_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6657,7 +6657,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_explain_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6670,7 +6670,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_explain_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6683,7 +6683,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_features_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6696,7 +6696,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_features_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6709,7 +6709,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_filemd5_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6722,7 +6722,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_filemd5_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6748,7 +6748,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_findAndModify_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6774,7 +6774,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_findAndModify_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6787,7 +6787,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_find_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6800,7 +6800,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_find_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6813,7 +6813,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_flushDatabaseCacheUpdates_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6826,7 +6826,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_flushDatabaseCacheUpdates_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6839,7 +6839,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_flushRouterConfig_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6852,7 +6852,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_flushRouterConfig_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6865,7 +6865,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_flushRoutingTableCacheUpdates_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6878,7 +6878,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_flushRoutingTableCacheUpdates_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6891,7 +6891,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_fsyncUnlock_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6904,7 +6904,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_fsyncUnlock_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6917,7 +6917,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_fsync_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6930,7 +6930,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_fsync_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6943,7 +6943,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_geoSearch_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6956,7 +6956,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_geoSearch_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6969,7 +6969,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getCmdLineOpts_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6982,7 +6982,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getCmdLineOpts_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6995,7 +6995,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getDatabaseVersion_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7008,7 +7008,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_getDatabaseVersion_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7021,7 +7021,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getDiagnosticData_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7034,7 +7034,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getDiagnosticData_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7047,7 +7047,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getFreeMonitoringStatus_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7060,7 +7060,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getFreeMonitoringStatus_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7073,7 +7073,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getLastError_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7086,7 +7086,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getLastError_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7099,7 +7099,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getLog_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7112,7 +7112,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getLog_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7125,7 +7125,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getMore_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7138,7 +7138,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getMore_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7151,7 +7151,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getNextSessionMods_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7164,7 +7164,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getNextSessionMods_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7177,7 +7177,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_getParameter_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7190,7 +7190,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getParameter_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7203,7 +7203,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_getShardMap_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7216,7 +7216,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_getShardMap_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7229,7 +7229,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getShardVersion_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7242,7 +7242,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getShardVersion_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7255,7 +7255,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getUserCacheGeneration_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7268,7 +7268,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getUserCacheGeneration_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7281,7 +7281,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getnonce_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7294,7 +7294,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getnonce_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7307,7 +7307,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_grantPrivilegesToRole_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7320,7 +7320,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_grantPrivilegesToRole_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7333,7 +7333,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_grantRolesToRole_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7346,7 +7346,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_grantRolesToRole_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7359,7 +7359,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_grantRolesToUser_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7372,7 +7372,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_grantRolesToUser_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7385,7 +7385,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_hello_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7398,7 +7398,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_hello_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7411,7 +7411,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_hostInfo_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7424,7 +7424,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_hostInfo_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7437,7 +7437,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_insert_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7450,7 +7450,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_insert_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7463,7 +7463,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_invalidateUserCache_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7476,7 +7476,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_invalidateUserCache_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7489,7 +7489,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_isMaster_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7502,7 +7502,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_isMaster_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7515,7 +7515,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_isSelf_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7528,7 +7528,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_isSelf_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7541,7 +7541,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_killAllSessionsByPattern_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7554,7 +7554,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_killAllSessionsByPattern_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7567,7 +7567,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_killAllSessions_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7580,7 +7580,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_killAllSessions_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7593,7 +7593,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_killCursors_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7606,7 +7606,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_killCursors_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7619,7 +7619,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_killOp_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7632,7 +7632,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_killOp_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7645,7 +7645,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_killSessions_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7658,7 +7658,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_killSessions_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7671,7 +7671,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_listCollections_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7684,7 +7684,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_listCollections_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7697,7 +7697,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_listCommands_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7710,7 +7710,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_listCommands_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7723,7 +7723,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_listDatabases_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7736,7 +7736,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_listDatabases_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7749,7 +7749,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_listIndexes_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7762,7 +7762,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_listIndexes_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7775,7 +7775,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_lockInfo_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7788,7 +7788,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_lockInfo_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7801,7 +7801,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_logRotate_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7814,7 +7814,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_logRotate_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7827,7 +7827,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_logout_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7840,7 +7840,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_logout_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7853,7 +7853,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_mapReduce_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7866,7 +7866,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_mapReduce_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7879,7 +7879,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_mapreduce_shardedfinish_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7892,7 +7892,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_mapreduce_shardedfinish_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7905,7 +7905,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_mergeAuthzCollections_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7918,7 +7918,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_mergeAuthzCollections_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7931,7 +7931,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_mergeChunks_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7944,7 +7944,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_mergeChunks_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7957,7 +7957,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_migrateClone_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7970,7 +7970,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_migrateClone_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7983,7 +7983,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_moveChunk_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7996,7 +7996,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_moveChunk_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8009,7 +8009,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_movePrimary_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8022,7 +8022,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_movePrimary_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8035,7 +8035,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_ping_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8048,7 +8048,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_ping_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8061,7 +8061,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_planCacheClearFilters_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8074,7 +8074,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_planCacheClearFilters_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8087,7 +8087,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_planCacheClear_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8100,7 +8100,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_planCacheClear_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8113,7 +8113,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_planCacheListFilters_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8126,7 +8126,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_planCacheListFilters_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8139,7 +8139,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_planCacheListPlans_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8152,7 +8152,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_planCacheListPlans_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8165,7 +8165,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_planCacheListQueryShapes_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8178,7 +8178,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_planCacheListQueryShapes_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8191,7 +8191,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_planCacheSetFilter_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8204,7 +8204,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_planCacheSetFilter_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8217,7 +8217,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_prepareTransaction_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8230,7 +8230,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_prepareTransaction_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8243,7 +8243,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_profile_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8256,7 +8256,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_profile_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8269,7 +8269,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_reIndex_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8282,7 +8282,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_reIndex_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8295,7 +8295,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_recvChunkAbort_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8308,7 +8308,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_recvChunkAbort_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8321,7 +8321,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_recvChunkCommit_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8334,7 +8334,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_recvChunkCommit_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8347,7 +8347,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_recvChunkStart_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8360,7 +8360,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_recvChunkStart_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8373,7 +8373,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_recvChunkStatus_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8386,7 +8386,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_recvChunkStatus_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8399,7 +8399,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_refreshSessions_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8412,7 +8412,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_refreshSessions_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8425,7 +8425,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_renameCollection_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8438,7 +8438,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_renameCollection_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8451,7 +8451,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_repairCursor_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8464,7 +8464,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_repairCursor_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8477,7 +8477,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_repairDatabase_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8490,7 +8490,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_repairDatabase_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8503,7 +8503,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_replSetAbortPrimaryCatchUp_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8516,7 +8516,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetAbortPrimaryCatchUp_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8529,7 +8529,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetFreeze_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8542,7 +8542,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_replSetFreeze_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8555,7 +8555,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetGetConfig_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8568,7 +8568,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetGetConfig_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8581,7 +8581,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetGetRBID_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8594,7 +8594,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetGetRBID_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8607,7 +8607,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetGetStatus_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8620,7 +8620,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_replSetGetStatus_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8633,7 +8633,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_replSetHeartbeat_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8646,7 +8646,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_replSetHeartbeat_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8659,7 +8659,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_replSetInitiate_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8672,7 +8672,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetInitiate_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8685,7 +8685,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetMaintenance_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8698,7 +8698,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetMaintenance_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8711,7 +8711,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_replSetReconfig_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8724,7 +8724,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_replSetReconfig_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8737,7 +8737,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetRequestVotes_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8750,7 +8750,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetRequestVotes_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8763,7 +8763,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetResizeOplog_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8776,7 +8776,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_replSetResizeOplog_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8789,7 +8789,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetStepDownWithForce_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8802,7 +8802,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_replSetStepDownWithForce_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8815,7 +8815,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_replSetStepDown_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8828,7 +8828,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetStepDown_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8841,7 +8841,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_replSetStepUp_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8854,7 +8854,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_replSetStepUp_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8867,7 +8867,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_replSetSyncFrom_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8880,7 +8880,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetSyncFrom_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8893,7 +8893,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_replSetUpdatePosition_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8906,7 +8906,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_replSetUpdatePosition_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8919,7 +8919,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_resetError_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8932,7 +8932,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_resetError_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8945,7 +8945,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_revokePrivilegesFromRole_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8958,7 +8958,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_revokePrivilegesFromRole_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8971,7 +8971,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_revokeRolesFromRole_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8984,7 +8984,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_revokeRolesFromRole_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8997,7 +8997,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_revokeRolesFromUser_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9010,7 +9010,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_revokeRolesFromUser_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9023,7 +9023,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_rolesInfo_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9036,7 +9036,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_rolesInfo_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9049,7 +9049,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_saslContinue_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9062,7 +9062,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_saslContinue_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9075,7 +9075,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_saslStart_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9088,7 +9088,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_saslStart_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9101,7 +9101,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_serverStatus_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9114,7 +9114,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_serverStatus_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9127,7 +9127,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_setFeatureCompatibilityVersion_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9140,7 +9140,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_setFeatureCompatibilityVersion_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9153,7 +9153,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_setFreeMonitoring_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9166,7 +9166,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_setFreeMonitoring_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9179,7 +9179,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_setParameter_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9192,7 +9192,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_setParameter_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9205,7 +9205,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_setShardVersion_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9218,7 +9218,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_setShardVersion_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9231,7 +9231,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_shardConnPoolStats_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9244,7 +9244,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_shardConnPoolStats_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9257,7 +9257,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_shardingState_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9270,7 +9270,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_shardingState_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9283,7 +9283,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_shardsvrSetAllowMigrations_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9296,7 +9296,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_shardsvrSetAllowMigrations_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9309,7 +9309,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_shardsvrShardCollection_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9322,7 +9322,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_shardsvrShardCollection_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9335,7 +9335,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_shutdown_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9348,7 +9348,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_shutdown_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9361,7 +9361,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_splitChunk_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9374,7 +9374,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_splitChunk_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9387,7 +9387,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_splitVector_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9400,7 +9400,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_splitVector_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9413,7 +9413,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_startRecordingTraffic_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9426,7 +9426,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_startRecordingTraffic_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9439,7 +9439,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_startSession_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9452,7 +9452,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_startSession_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9465,7 +9465,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_stopRecordingTraffic_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9478,7 +9478,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_stopRecordingTraffic_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9491,7 +9491,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_top_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9504,7 +9504,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_top_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9517,7 +9517,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_touch_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9530,7 +9530,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_touch_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9543,7 +9543,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_transferMods_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9556,7 +9556,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_transferMods_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9569,7 +9569,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_unsetSharding_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9582,7 +9582,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_unsetSharding_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9595,7 +9595,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_updateRole_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9608,7 +9608,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_updateRole_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9621,7 +9621,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_updateUser_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9634,7 +9634,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_updateUser_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9660,7 +9660,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_update_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9686,7 +9686,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_update_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9699,7 +9699,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_usersInfo_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9712,7 +9712,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_usersInfo_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9725,7 +9725,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_validate_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9738,7 +9738,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_validate_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9751,7 +9751,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_voteCommitIndexBuild_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9764,7 +9764,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_voteCommitIndexBuild_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9777,7 +9777,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_waitForFailPoint_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9790,7 +9790,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_waitForFailPoint_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9803,7 +9803,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_whatsmyuri_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9816,7 +9816,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_whatsmyuri_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12193,7 +12193,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_transactions_totalAborted
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12206,7 +12206,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_transactions_totalCommitted
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12219,7 +12219,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_transactions_totalPrepared
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12232,7 +12232,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_transactions_totalPreparedThenAborted
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12245,7 +12245,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_transactions_totalPreparedThenCommitted
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12258,7 +12258,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_transactions_totalStarted
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12414,7 +12414,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_twoPhaseCommitCoordinator_totalAbortedTwoPhaseCommit
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12427,7 +12427,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_twoPhaseCommitCoordinator_totalCommittedTwoPhaseCommit
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12453,7 +12453,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_twoPhaseCommitCoordinator_totalStartedTwoPhaseCommit
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12570,7 +12570,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_wt_async_number_of_times_operation_allocation_failed
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12596,7 +12596,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_wt_async_total_allocations
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12609,7 +12609,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_wt_async_total_compact_calls
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12622,7 +12622,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_wt_async_total_insert_calls
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12635,7 +12635,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_wt_async_total_remove_calls
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12648,7 +12648,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_wt_async_total_search_calls
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12661,7 +12661,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_wt_async_total_update_calls
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -14377,7 +14377,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_wt_capacity_bytes_written_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: bytes
         dimensions:
@@ -14671,7 +14671,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_wt_connection_total_write_I_Os
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -16088,7 +16088,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_wt_log_total_in_memory_size_of_compressed_records
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -16610,7 +16610,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_wt_snapshot_window_settings_total_number_of_SnapshotTooOld_errors
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -16922,7 +16922,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_wt_txn_durable_timestamp_queue_inserts_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -17078,7 +17078,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_wt_txn_read_timestamp_queue_inserts_total
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:
@@ -21705,7 +21705,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_top_total_time
-        type: gauge
+        type: count
         defaultResolution: 15
         unit: count
         dimensions:

--- a/exporters/mongodb/e2e/mongodb.yml
+++ b/exporters/mongodb/e2e/mongodb.yml
@@ -4876,7 +4876,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_abortTransaction_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -4889,7 +4889,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_abortTransaction_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -4902,7 +4902,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_addShard_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -4915,7 +4915,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_addShard_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -4941,7 +4941,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_aggregate_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -4954,7 +4954,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_aggregate_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -4967,7 +4967,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_appendOplogNote_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -4980,7 +4980,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_appendOplogNote_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -4993,7 +4993,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_applyOps_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5006,7 +5006,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_applyOps_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5019,7 +5019,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_authenticate_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5032,7 +5032,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_authenticate_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5045,7 +5045,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_autoSplitVector_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5058,7 +5058,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_autoSplitVector_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5071,7 +5071,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_availableQueryOptions_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5084,7 +5084,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_availableQueryOptions_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5097,7 +5097,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_buildInfo_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5110,7 +5110,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_buildInfo_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5123,7 +5123,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_checkShardingIndex_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5136,7 +5136,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_checkShardingIndex_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5149,7 +5149,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_cleanupOrphaned_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5162,7 +5162,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_cleanupOrphaned_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5175,7 +5175,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_cloneCatalogData_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5188,7 +5188,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_cloneCatalogData_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5201,7 +5201,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_cloneCollectionAsCapped_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5214,7 +5214,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_cloneCollectionAsCapped_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5227,7 +5227,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_cloneCollectionOptionsFromPrimaryShard_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5240,7 +5240,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_cloneCollectionOptionsFromPrimaryShard_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5253,7 +5253,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_cloneCollection_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5266,7 +5266,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_cloneCollection_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5279,7 +5279,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_collMod_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5292,7 +5292,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_collMod_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5305,7 +5305,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_collStats_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5318,7 +5318,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_collStats_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5331,7 +5331,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_commitTransaction_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5344,7 +5344,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_commitTransaction_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5357,7 +5357,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_compact_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5370,7 +5370,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_compact_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5383,7 +5383,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrAddShardToZone_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5396,7 +5396,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrAddShardToZone_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5409,7 +5409,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrAddShard_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5422,7 +5422,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrAddShard_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5435,7 +5435,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_configsvrBalancerStart_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5448,7 +5448,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrBalancerStart_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5461,7 +5461,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_configsvrBalancerStatus_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5474,7 +5474,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrBalancerStatus_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5487,7 +5487,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_configsvrBalancerStop_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5500,7 +5500,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_configsvrBalancerStop_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5513,7 +5513,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrClearJumboFlag_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5526,7 +5526,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrClearJumboFlag_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5539,7 +5539,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCommitChunkMerge_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5552,7 +5552,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCommitChunkMerge_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5565,7 +5565,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCommitChunkMigration_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5578,7 +5578,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCommitChunkMigration_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5591,7 +5591,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCommitChunkSplit_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5604,7 +5604,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCommitChunkSplit_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5617,7 +5617,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCommitChunksMerge_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5630,7 +5630,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCommitChunksMerge_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5643,7 +5643,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCommitMovePrimary_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5656,7 +5656,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCommitMovePrimary_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5669,7 +5669,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCreateCollection_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5682,7 +5682,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCreateCollection_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5695,7 +5695,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCreateDatabase_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5708,7 +5708,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrCreateDatabase_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5721,7 +5721,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrDropCollection_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5734,7 +5734,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_configsvrDropCollection_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5747,7 +5747,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrDropDatabase_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5760,7 +5760,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrDropDatabase_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5773,7 +5773,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_configsvrEnableSharding_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5786,7 +5786,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrEnableSharding_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5799,7 +5799,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_configsvrMoveChunk_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5812,7 +5812,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrMoveChunk_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5825,7 +5825,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_configsvrMovePrimary_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5838,7 +5838,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrMovePrimary_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5851,7 +5851,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrRemoveShardFromZone_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5864,7 +5864,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrRemoveShardFromZone_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5877,7 +5877,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrRemoveShard_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5890,7 +5890,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_configsvrRemoveShard_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5903,7 +5903,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrRepairShardedCollectionChunksHistory_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5916,7 +5916,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrRepairShardedCollectionChunksHistory_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5929,7 +5929,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrShardCollection_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5942,7 +5942,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_configsvrShardCollection_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5955,7 +5955,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_configsvrUpdateZoneKeyRange_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5968,7 +5968,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_configsvrUpdateZoneKeyRange_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5981,7 +5981,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_connPoolStats_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -5994,7 +5994,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_connPoolStats_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6007,7 +6007,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_connPoolSync_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6020,7 +6020,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_connPoolSync_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6033,7 +6033,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_connectionStatus_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6046,7 +6046,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_connectionStatus_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6059,7 +6059,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_convertToCapped_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6072,7 +6072,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_convertToCapped_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6085,7 +6085,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_coordinateCommitTransaction_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6098,7 +6098,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_coordinateCommitTransaction_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6111,7 +6111,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_count_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6124,7 +6124,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_count_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6137,7 +6137,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_createIndexes_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6150,7 +6150,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_createIndexes_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6163,7 +6163,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_createRole_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6176,7 +6176,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_createRole_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6189,7 +6189,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_createUser_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6202,7 +6202,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_createUser_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6215,7 +6215,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_create_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6228,7 +6228,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_create_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6241,7 +6241,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_currentOp_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6254,7 +6254,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_currentOp_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6267,7 +6267,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_dataSize_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6280,7 +6280,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_dataSize_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6293,7 +6293,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_dbHash_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6306,7 +6306,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_dbHash_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6319,7 +6319,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_dbStats_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6332,7 +6332,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_dbStats_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6345,7 +6345,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_delete_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6358,7 +6358,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_delete_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6371,7 +6371,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_distinct_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6384,7 +6384,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_distinct_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6397,7 +6397,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_driverOIDTest_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6410,7 +6410,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_driverOIDTest_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6423,7 +6423,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_dropAllRolesFromDatabase_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6436,7 +6436,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_dropAllRolesFromDatabase_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6449,7 +6449,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_dropAllUsersFromDatabase_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6462,7 +6462,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_dropAllUsersFromDatabase_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6475,7 +6475,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_dropConnections_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6488,7 +6488,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_dropConnections_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6501,7 +6501,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_dropDatabase_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6514,7 +6514,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_dropDatabase_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6527,7 +6527,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_dropIndexes_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6540,7 +6540,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_dropIndexes_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6553,7 +6553,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_dropRole_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6566,7 +6566,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_dropRole_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6579,7 +6579,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_dropUser_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6592,7 +6592,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_dropUser_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6605,7 +6605,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_drop_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6618,7 +6618,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_drop_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6631,7 +6631,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_endSessions_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6644,7 +6644,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_endSessions_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6657,7 +6657,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_explain_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6670,7 +6670,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_explain_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6683,7 +6683,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_features_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6696,7 +6696,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_features_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6709,7 +6709,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_filemd5_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6722,7 +6722,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_filemd5_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6748,7 +6748,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_findAndModify_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6774,7 +6774,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_findAndModify_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6787,7 +6787,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_find_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6800,7 +6800,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_find_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6813,7 +6813,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_flushDatabaseCacheUpdates_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6826,7 +6826,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_flushDatabaseCacheUpdates_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6839,7 +6839,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_flushRouterConfig_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6852,7 +6852,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_flushRouterConfig_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6865,7 +6865,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_flushRoutingTableCacheUpdates_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6878,7 +6878,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_flushRoutingTableCacheUpdates_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6891,7 +6891,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_fsyncUnlock_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6904,7 +6904,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_fsyncUnlock_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6917,7 +6917,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_fsync_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6930,7 +6930,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_fsync_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6943,7 +6943,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_geoSearch_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6956,7 +6956,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_geoSearch_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6969,7 +6969,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getCmdLineOpts_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6982,7 +6982,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getCmdLineOpts_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -6995,7 +6995,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getDatabaseVersion_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7008,7 +7008,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_getDatabaseVersion_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7021,7 +7021,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getDiagnosticData_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7034,7 +7034,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getDiagnosticData_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7047,7 +7047,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getFreeMonitoringStatus_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7060,7 +7060,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getFreeMonitoringStatus_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7073,7 +7073,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getLastError_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7086,7 +7086,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getLastError_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7099,7 +7099,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getLog_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7112,7 +7112,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getLog_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7125,7 +7125,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getMore_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7138,7 +7138,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getMore_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7151,7 +7151,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getNextSessionMods_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7164,7 +7164,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getNextSessionMods_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7177,7 +7177,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_getParameter_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7190,7 +7190,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getParameter_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7203,7 +7203,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_getShardMap_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7216,7 +7216,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_getShardMap_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7229,7 +7229,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getShardVersion_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7242,7 +7242,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getShardVersion_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7255,7 +7255,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getUserCacheGeneration_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7268,7 +7268,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getUserCacheGeneration_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7281,7 +7281,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getnonce_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7294,7 +7294,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_getnonce_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7307,7 +7307,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_grantPrivilegesToRole_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7320,7 +7320,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_grantPrivilegesToRole_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7333,7 +7333,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_grantRolesToRole_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7346,7 +7346,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_grantRolesToRole_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7359,7 +7359,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_grantRolesToUser_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7372,7 +7372,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_grantRolesToUser_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7385,7 +7385,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_hello_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7398,7 +7398,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_hello_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7411,7 +7411,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_hostInfo_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7424,7 +7424,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_hostInfo_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7437,7 +7437,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_insert_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7450,7 +7450,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_insert_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7463,7 +7463,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_invalidateUserCache_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7476,7 +7476,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_invalidateUserCache_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7489,7 +7489,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_isMaster_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7502,7 +7502,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_isMaster_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7515,7 +7515,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_isSelf_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7528,7 +7528,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_isSelf_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7541,7 +7541,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_killAllSessionsByPattern_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7554,7 +7554,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_killAllSessionsByPattern_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7567,7 +7567,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_killAllSessions_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7580,7 +7580,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_killAllSessions_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7593,7 +7593,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_killCursors_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7606,7 +7606,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_killCursors_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7619,7 +7619,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_killOp_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7632,7 +7632,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_killOp_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7645,7 +7645,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_killSessions_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7658,7 +7658,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_killSessions_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7671,7 +7671,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_listCollections_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7684,7 +7684,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_listCollections_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7697,7 +7697,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_listCommands_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7710,7 +7710,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_listCommands_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7723,7 +7723,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_listDatabases_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7736,7 +7736,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_listDatabases_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7749,7 +7749,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_listIndexes_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7762,7 +7762,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_listIndexes_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7775,7 +7775,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_lockInfo_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7788,7 +7788,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_lockInfo_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7801,7 +7801,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_logRotate_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7814,7 +7814,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_logRotate_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7827,7 +7827,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_logout_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7840,7 +7840,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_logout_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7853,7 +7853,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_mapReduce_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7866,7 +7866,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_mapReduce_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7879,7 +7879,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_mapreduce_shardedfinish_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7892,7 +7892,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_mapreduce_shardedfinish_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7905,7 +7905,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_mergeAuthzCollections_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7918,7 +7918,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_mergeAuthzCollections_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7931,7 +7931,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_mergeChunks_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7944,7 +7944,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_mergeChunks_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7957,7 +7957,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_migrateClone_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7970,7 +7970,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_migrateClone_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7983,7 +7983,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_moveChunk_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -7996,7 +7996,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_moveChunk_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8009,7 +8009,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_movePrimary_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8022,7 +8022,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_movePrimary_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8035,7 +8035,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_ping_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8048,7 +8048,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_ping_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8061,7 +8061,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_planCacheClearFilters_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8074,7 +8074,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_planCacheClearFilters_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8087,7 +8087,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_planCacheClear_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8100,7 +8100,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_planCacheClear_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8113,7 +8113,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_planCacheListFilters_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8126,7 +8126,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_planCacheListFilters_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8139,7 +8139,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_planCacheListPlans_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8152,7 +8152,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_planCacheListPlans_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8165,7 +8165,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_planCacheListQueryShapes_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8178,7 +8178,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_planCacheListQueryShapes_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8191,7 +8191,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_planCacheSetFilter_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8204,7 +8204,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_planCacheSetFilter_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8217,7 +8217,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_prepareTransaction_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8230,7 +8230,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_prepareTransaction_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8243,7 +8243,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_profile_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8256,7 +8256,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_profile_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8269,7 +8269,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_reIndex_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8282,7 +8282,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_reIndex_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8295,7 +8295,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_recvChunkAbort_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8308,7 +8308,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_recvChunkAbort_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8321,7 +8321,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_recvChunkCommit_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8334,7 +8334,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_recvChunkCommit_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8347,7 +8347,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_recvChunkStart_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8360,7 +8360,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_recvChunkStart_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8373,7 +8373,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_recvChunkStatus_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8386,7 +8386,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_recvChunkStatus_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8399,7 +8399,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_refreshSessions_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8412,7 +8412,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_refreshSessions_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8425,7 +8425,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_renameCollection_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8438,7 +8438,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_renameCollection_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8451,7 +8451,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_repairCursor_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8464,7 +8464,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_repairCursor_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8477,7 +8477,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_repairDatabase_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8490,7 +8490,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_repairDatabase_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8503,7 +8503,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_replSetAbortPrimaryCatchUp_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8516,7 +8516,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetAbortPrimaryCatchUp_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8529,7 +8529,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetFreeze_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8542,7 +8542,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_replSetFreeze_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8555,7 +8555,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetGetConfig_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8568,7 +8568,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetGetConfig_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8581,7 +8581,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetGetRBID_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8594,7 +8594,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetGetRBID_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8607,7 +8607,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetGetStatus_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8620,7 +8620,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_replSetGetStatus_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8633,7 +8633,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_replSetHeartbeat_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8646,7 +8646,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_replSetHeartbeat_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8659,7 +8659,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_replSetInitiate_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8672,7 +8672,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetInitiate_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8685,7 +8685,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetMaintenance_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8698,7 +8698,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetMaintenance_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8711,7 +8711,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_replSetReconfig_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8724,7 +8724,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_replSetReconfig_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8737,7 +8737,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetRequestVotes_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8750,7 +8750,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetRequestVotes_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8763,7 +8763,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetResizeOplog_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8776,7 +8776,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_replSetResizeOplog_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8789,7 +8789,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetStepDownWithForce_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8802,7 +8802,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_replSetStepDownWithForce_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8815,7 +8815,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_replSetStepDown_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8828,7 +8828,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetStepDown_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8841,7 +8841,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_replSetStepUp_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8854,7 +8854,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_replSetStepUp_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8867,7 +8867,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_replSetSyncFrom_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8880,7 +8880,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_replSetSyncFrom_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8893,7 +8893,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_replSetUpdatePosition_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8906,7 +8906,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_replSetUpdatePosition_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8919,7 +8919,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_resetError_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8932,7 +8932,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_resetError_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8945,7 +8945,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_revokePrivilegesFromRole_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8958,7 +8958,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_revokePrivilegesFromRole_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8971,7 +8971,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_revokeRolesFromRole_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8984,7 +8984,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_revokeRolesFromRole_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -8997,7 +8997,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_revokeRolesFromUser_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9010,7 +9010,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_revokeRolesFromUser_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9023,7 +9023,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_rolesInfo_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9036,7 +9036,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_rolesInfo_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9049,7 +9049,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_saslContinue_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9062,7 +9062,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_saslContinue_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9075,7 +9075,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_saslStart_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9088,7 +9088,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_saslStart_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9101,7 +9101,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_serverStatus_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9114,7 +9114,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_serverStatus_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9127,7 +9127,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_setFeatureCompatibilityVersion_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9140,7 +9140,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_setFeatureCompatibilityVersion_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9153,7 +9153,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_setFreeMonitoring_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9166,7 +9166,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_setFreeMonitoring_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9179,7 +9179,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_setParameter_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9192,7 +9192,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_setParameter_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9205,7 +9205,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_setShardVersion_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9218,7 +9218,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_setShardVersion_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9231,7 +9231,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_shardConnPoolStats_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9244,7 +9244,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_shardConnPoolStats_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9257,7 +9257,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_shardingState_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9270,7 +9270,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_shardingState_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9283,7 +9283,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_shardsvrSetAllowMigrations_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9296,7 +9296,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_shardsvrSetAllowMigrations_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9309,7 +9309,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_shardsvrShardCollection_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9322,7 +9322,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_shardsvrShardCollection_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9335,7 +9335,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_shutdown_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9348,7 +9348,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_shutdown_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9361,7 +9361,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_splitChunk_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9374,7 +9374,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_splitChunk_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9387,7 +9387,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_splitVector_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9400,7 +9400,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_splitVector_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9413,7 +9413,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_startRecordingTraffic_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9426,7 +9426,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_startRecordingTraffic_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9439,7 +9439,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_startSession_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9452,7 +9452,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_startSession_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9465,7 +9465,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_stopRecordingTraffic_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9478,7 +9478,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_stopRecordingTraffic_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9491,7 +9491,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_top_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9504,7 +9504,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_top_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9517,7 +9517,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_touch_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9530,7 +9530,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_touch_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9543,7 +9543,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_transferMods_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9556,7 +9556,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_transferMods_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9569,7 +9569,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_unsetSharding_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9582,7 +9582,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_unsetSharding_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9595,7 +9595,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_updateRole_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9608,7 +9608,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_updateRole_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9621,7 +9621,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_updateUser_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9634,7 +9634,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_updateUser_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9660,7 +9660,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_update_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9686,7 +9686,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_update_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9699,7 +9699,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_metrics_commands_usersInfo_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9712,7 +9712,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_usersInfo_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9725,7 +9725,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_validate_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9738,7 +9738,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_validate_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9751,7 +9751,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_voteCommitIndexBuild_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9764,7 +9764,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_metrics_commands_voteCommitIndexBuild_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9777,7 +9777,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_waitForFailPoint_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9790,7 +9790,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_metrics_commands_waitForFailPoint_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9803,7 +9803,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_whatsmyuri_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -9816,7 +9816,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_metrics_commands_whatsmyuri_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12193,7 +12193,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_transactions_totalAborted
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12206,7 +12206,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_transactions_totalCommitted
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12219,7 +12219,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_transactions_totalPrepared
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12232,7 +12232,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_transactions_totalPreparedThenAborted
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12245,7 +12245,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_transactions_totalPreparedThenCommitted
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12258,7 +12258,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_transactions_totalStarted
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12414,7 +12414,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_twoPhaseCommitCoordinator_totalAbortedTwoPhaseCommit
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12427,7 +12427,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_twoPhaseCommitCoordinator_totalCommittedTwoPhaseCommit
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12453,7 +12453,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_twoPhaseCommitCoordinator_totalStartedTwoPhaseCommit
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12570,7 +12570,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_wt_async_number_of_times_operation_allocation_failed
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12596,7 +12596,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_wt_async_total_allocations
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12609,7 +12609,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_wt_async_total_compact_calls
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12622,7 +12622,7 @@ entities:
           - name: cl_role
             type: string
       - name: mongodb_ss_wt_async_total_insert_calls
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12635,7 +12635,7 @@ entities:
           - name: cl_id
             type: string
       - name: mongodb_ss_wt_async_total_remove_calls
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12648,7 +12648,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_wt_async_total_search_calls
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -12661,7 +12661,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_wt_async_total_update_calls
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -14377,7 +14377,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_wt_capacity_bytes_written_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: bytes
         dimensions:
@@ -14671,7 +14671,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_wt_connection_total_write_I_Os
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -16088,7 +16088,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_wt_log_total_in_memory_size_of_compressed_records
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -16610,7 +16610,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_wt_snapshot_window_settings_total_number_of_SnapshotTooOld_errors
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -16922,7 +16922,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_ss_wt_txn_durable_timestamp_queue_inserts_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -17078,7 +17078,7 @@ entities:
           - name: rs_state
             type: string
       - name: mongodb_ss_wt_txn_read_timestamp_queue_inserts_total
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:
@@ -21705,7 +21705,7 @@ entities:
           - name: rs_nm
             type: string
       - name: mongodb_top_total_time
-        type: count
+        type: gauge
         defaultResolution: 15
         unit: count
         dimensions:

--- a/exporters/mongodb/e2e/mongodb.yml
+++ b/exporters/mongodb/e2e/mongodb.yml
@@ -1,0 +1,22048 @@
+specVersion: "2"
+owningTeam: integrations
+integrationName: mongodb
+humanReadableIntegrationName: MongoDB
+entities:
+  - entityType: MONGODB_INSTANCE
+    metrics:
+      - name: collector_scrape_time_ms
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: collector
+            type: string
+          - name: exporter
+            type: string
+      - name: mongodb_clusterTime_signature_keyId
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_date
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_heartbeatIntervalMillis
+        type: gauge
+        defaultResolution: 15
+        unit: milliseconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_members_configVersion
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: member_idx
+            type: string
+          - name: member_state
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_members_electionDate
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: member_idx
+            type: string
+          - name: member_state
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_members_health
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: member_idx
+            type: string
+          - name: member_state
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_members_id
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: member_idx
+            type: string
+          - name: member_state
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_members_lastHeartbeat
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: member_idx
+            type: string
+          - name: member_state
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_members_lastHeartbeatRecv
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: member_idx
+            type: string
+          - name: member_state
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_members_optimeDate
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: member_idx
+            type: string
+          - name: member_state
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_members_optimeDurableDate
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: member_idx
+            type: string
+          - name: member_state
+            type: string
+      - name: mongodb_members_optimeDurable_t
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: member_idx
+            type: string
+          - name: member_state
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_members_optime_t
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: member_state
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: member_idx
+            type: string
+      - name: mongodb_members_pingMs
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: member_idx
+            type: string
+          - name: member_state
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_members_self
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: member_idx
+            type: string
+          - name: member_state
+            type: string
+      - name: mongodb_members_state
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: member_idx
+            type: string
+          - name: member_state
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_members_syncSourceId
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: member_idx
+            type: string
+          - name: member_state
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_members_uptime
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: member_idx
+            type: string
+          - name: member_state
+            type: string
+      - name: mongodb_oplog_stats_avgObjSize
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_capped
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_oplog_stats_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_oplog_stats_end
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_oplog_stats_max
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_maxSize
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_nindexes
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_ok
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_scaleFactor
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_size
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_oplog_stats_sleepCount
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_sleepMS
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_start
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_oplog_stats_storageSize
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_oplog_stats_totalIndexSize
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_oplog_stats_wt_LSM_bloom_filter_false_positives
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_oplog_stats_wt_LSM_bloom_filter_hits
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_LSM_bloom_filter_misses
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_oplog_stats_wt_LSM_bloom_filter_pages_evicted_from_cache
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_LSM_bloom_filter_pages_read_into_cache
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_oplog_stats_wt_LSM_bloom_filters_in_the_LSM_tree
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_oplog_stats_wt_LSM_chunks_in_the_LSM_tree
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_LSM_highest_merge_generation_in_the_LSM_tree
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_oplog_stats_wt_LSM_queries_that_could_have_benefited_from_a_Bloom_filter_that_did_not_exist
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_oplog_stats_wt_LSM_sleep_for_LSM_checkpoint_throttle
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_oplog_stats_wt_LSM_sleep_for_LSM_merge_throttle
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_LSM_total_size_of_bloom_filters
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_oplog_stats_wt_block_manager_allocations_requiring_file_extension
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_block_manager_blocks_allocated
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_block_manager_blocks_freed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_block_manager_checkpoint_size
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_oplog_stats_wt_block_manager_file_allocation_unit_size
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_block_manager_file_bytes_available_for_reuse
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_oplog_stats_wt_block_manager_file_magic_number
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_block_manager_file_major_version_number
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_block_manager_file_size_in_bytes
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_oplog_stats_wt_block_manager_minor_version_number
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_oplog_stats_wt_btree_btree_checkpoint_generation
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_btree_btree_clean_tree_checkpoint_expiration_time
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_oplog_stats_wt_btree_column_store_fixed_size_leaf_pages
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_oplog_stats_wt_btree_column_store_internal_pages
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_oplog_stats_wt_btree_column_store_variable_size_RLE_encoded_values
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_btree_column_store_variable_size_deleted_values
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_oplog_stats_wt_btree_column_store_variable_size_leaf_pages
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_btree_fixed_record_size
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_btree_maximum_internal_page_key_size
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_btree_maximum_internal_page_size
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_oplog_stats_wt_btree_maximum_leaf_page_key_size
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_btree_maximum_leaf_page_size
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_btree_maximum_leaf_page_value_size
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_oplog_stats_wt_btree_maximum_tree_depth
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_btree_number_of_key_value_pairs
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_btree_overflow_pages
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_btree_pages_rewritten_by_compaction
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_btree_row_store_empty_values
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_btree_row_store_internal_pages
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_btree_row_store_leaf_pages
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_bytes_currently_in_the_cache
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_bytes_dirty_in_the_cache_cumulative
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_bytes_read_into_cache
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_bytes_written_from_cache
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_checkpoint_blocked_page_eviction
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_data_source_pages_selected_for_eviction_unable_to_be_evicted
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_eviction_walk_passes_of_a_file
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_eviction_walk_target_pages_histogram_0_9
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_eviction_walk_target_pages_histogram_10_31
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_eviction_walk_target_pages_histogram_128_and_higher
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_eviction_walk_target_pages_histogram_32_63
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_eviction_walk_target_pages_histogram_64_128
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_eviction_walks_abandoned
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_eviction_walks_gave_up_because_they_restarted_their_walk_twice
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_eviction_walks_gave_up_because_they_saw_too_many_pages_and_found_no_candidates
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_eviction_walks_gave_up_because_they_saw_too_many_pages_and_found_too_few_candidates
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_eviction_walks_reached_end_of_tree
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_eviction_walks_started_from_root_of_tree
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_eviction_walks_started_from_saved_location_in_tree
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_hazard_pointer_blocked_page_eviction
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_in_memory_page_passed_criteria_to_be_split
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_in_memory_page_splits
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_internal_pages_evicted
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_internal_pages_split_during_eviction
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_leaf_pages_split_during_eviction
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_modified_pages_evicted
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_overflow_pages_read_into_cache
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_page_split_during_eviction_deepened_the_tree
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_page_written_requiring_cache_overflow_records
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_pages_read_into_cache
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_pages_read_into_cache_after_truncate
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_pages_read_into_cache_after_truncate_in_prepare_state
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_pages_read_into_cache_requiring_cache_overflow_entries
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_pages_requested_from_the_cache
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_pages_seen_by_eviction_walk
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_pages_written_from_cache
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_pages_written_requiring_in_memory_restoration
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_tracked_dirty_bytes_in_the_cache
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_unmodified_pages_evicted
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_walk_Average_difference_between_current_eviction_generation_when_the_page_was_last_considered
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_walk_Average_on_disk_page_image_size_seen
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_walk_Average_time_in_cache_for_pages_that_have_been_visited_by_the_eviction_server
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_walk_Average_time_in_cache_for_pages_that_have_not_been_visited_by_the_eviction_server
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_walk_Clean_pages_currently_in_cache
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_walk_Current_eviction_generation
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_walk_Dirty_pages_currently_in_cache
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_walk_Entries_in_the_root_page
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_walk_Internal_pages_currently_in_cache
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_walk_Leaf_pages_currently_in_cache
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_walk_Maximum_difference_between_current_eviction_generation_when_the_page_was_last_considered
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_walk_Maximum_page_size_seen
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_walk_Minimum_on_disk_page_image_size_seen
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_walk_Number_of_pages_never_visited_by_eviction_server
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_walk_On_disk_page_image_sizes_smaller_than_a_single_allocation_unit
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_walk_Pages_created_in_memory_and_never_written
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_walk_Pages_currently_queued_for_eviction
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_walk_Pages_that_could_not_be_queued_for_eviction
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_walk_Refs_skipped_during_cache_traversal
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_walk_Size_of_the_root_page
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_oplog_stats_wt_cache_walk_Total_number_of_pages_currently_in_cache
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_compression_compressed_page_maximum_internal_page_size_prior_to_compression
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_compression_compressed_page_maximum_leaf_page_size_prior_to_compression
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_compression_compressed_pages_read
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_compression_compressed_pages_written
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_compression_page_written_failed_to_compress
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_compression_page_written_was_too_small_to_compress
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cursor_bulk_loaded_cursor_insert_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cursor_cache_cursors_reuse_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cursor_close_calls_that_result_in_cache
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_oplog_stats_wt_cursor_create_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_oplog_stats_wt_cursor_insert_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cursor_insert_key_and_value_bytes
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cursor_modify
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_oplog_stats_wt_cursor_modify_key_and_value_bytes_affected
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_oplog_stats_wt_cursor_modify_value_bytes_modified
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_oplog_stats_wt_cursor_next_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_oplog_stats_wt_cursor_open_cursor_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cursor_operation_restarted
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_oplog_stats_wt_cursor_prev_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_oplog_stats_wt_cursor_remove_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_oplog_stats_wt_cursor_remove_key_bytes_removed
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_oplog_stats_wt_cursor_reserve_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cursor_reset_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cursor_search_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_oplog_stats_wt_cursor_search_near_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cursor_truncate_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_oplog_stats_wt_cursor_update_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cursor_update_key_and_value_bytes
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_cursor_update_value_size_change
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_oplog_stats_wt_metadata_formatVersion
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_metadata_oplogKeyExtractionVersion
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_reconciliation_dictionary_matches
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_reconciliation_fast_path_pages_deleted
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_reconciliation_internal_page_key_bytes_discarded_using_suffix_compression
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_reconciliation_internal_page_multi_block_writes
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_reconciliation_internal_page_overflow_keys
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_reconciliation_leaf_page_key_bytes_discarded_using_prefix_compression
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_oplog_stats_wt_reconciliation_leaf_page_multi_block_writes
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_reconciliation_leaf_page_overflow_keys
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_oplog_stats_wt_reconciliation_maximum_blocks_required_for_a_page
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_reconciliation_overflow_values_written
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_oplog_stats_wt_reconciliation_page_checksum_matches
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_oplog_stats_wt_reconciliation_page_reconciliation_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_reconciliation_page_reconciliation_calls_for_eviction
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_oplog_stats_wt_reconciliation_pages_deleted
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_session_object_compaction
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_oplog_stats_wt_transaction_update_conflicts
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_optimes_appliedOpTime_t
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_optimes_durableOpTime_t
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_optimes_lastAppliedWallTime
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_optimes_lastCommittedOpTime_t
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_optimes_lastCommittedWallTime
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_optimes_lastDurableWallTime
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_optimes_readConcernMajorityOpTime_t
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_optimes_readConcernMajorityWallTime
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_rs_date
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_rs_electionCandidateMetrics_electionTerm
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_rs_electionCandidateMetrics_electionTimeoutMillis
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_rs_electionCandidateMetrics_lastCommittedOpTimeAtElection_t
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_rs_electionCandidateMetrics_lastElectionDate
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_rs_electionCandidateMetrics_lastSeenOpTimeAtElection_t
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_rs_electionCandidateMetrics_newTermStartDate
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_rs_electionCandidateMetrics_numCatchUpOps
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_rs_electionCandidateMetrics_numVotesNeeded
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_rs_electionCandidateMetrics_priorityAtElection
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_rs_electionCandidateMetrics_wMajorityWriteAvailabilityDate
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_rs_end
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_rs_heartbeatIntervalMillis
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_rs_majorityVoteCount
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_rs_members_configVersion
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: member_idx
+            type: string
+          - name: member_state
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_rs_members_electionDate
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: member_idx
+            type: string
+          - name: member_state
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_rs_members_health
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: member_idx
+            type: string
+          - name: member_state
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_rs_members_id
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: member_idx
+            type: string
+          - name: member_state
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_rs_members_lastHeartbeat
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: member_idx
+            type: string
+          - name: member_state
+            type: string
+      - name: mongodb_rs_members_lastHeartbeatRecv
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: member_idx
+            type: string
+          - name: member_state
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_rs_members_optimeDate
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: member_idx
+            type: string
+          - name: member_state
+            type: string
+      - name: mongodb_rs_members_optimeDurableDate
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: member_idx
+            type: string
+          - name: member_state
+            type: string
+      - name: mongodb_rs_members_optimeDurable_t
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: member_state
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: member_idx
+            type: string
+      - name: mongodb_rs_members_optime_t
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: member_idx
+            type: string
+          - name: member_state
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_rs_members_pingMs
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: member_idx
+            type: string
+          - name: member_state
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_rs_members_self
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: member_state
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: member_idx
+            type: string
+      - name: mongodb_rs_members_state
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: member_idx
+            type: string
+          - name: member_state
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_rs_members_syncSourceId
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: member_idx
+            type: string
+          - name: member_state
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_rs_members_uptime
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: member_idx
+            type: string
+          - name: member_state
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_rs_myState
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_rs_ok
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_rs_optimes_appliedOpTime_t
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_rs_optimes_durableOpTime_t
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_rs_optimes_lastAppliedWallTime
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_rs_optimes_lastCommittedOpTime_t
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_rs_optimes_lastCommittedWallTime
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_rs_optimes_lastDurableWallTime
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_rs_optimes_readConcernMajorityOpTime_t
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_rs_optimes_readConcernMajorityWallTime
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_rs_start
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_rs_syncSourceId
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_rs_term
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_rs_writeMajorityCount
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_asserts
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: assert_type
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_connections
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: conn_type
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_electionMetrics_averageCatchUpOps
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_electionMetrics_catchUpTakeover_called
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_electionMetrics_catchUpTakeover_successful
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_electionMetrics_electionTimeout_called
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_electionMetrics_electionTimeout_successful
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_electionMetrics_freezeTimeout_called
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_electionMetrics_freezeTimeout_successful
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_electionMetrics_numCatchUps
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_electionMetrics_numCatchUpsAlreadyCaughtUp
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_electionMetrics_numCatchUpsFailedWithError
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_electionMetrics_numCatchUpsFailedWithNewTerm
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_electionMetrics_numCatchUpsFailedWithReplSetAbortPrimaryCatchUpCmd
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_electionMetrics_numCatchUpsSkipped
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_electionMetrics_numCatchUpsSucceeded
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_electionMetrics_numCatchUpsTimedOut
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_electionMetrics_numStepDownsCausedByHigherTerm
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_electionMetrics_priorityTakeover_called
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_electionMetrics_priorityTakeover_successful
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_electionMetrics_stepUpCmd_called
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_electionMetrics_stepUpCmd_successful
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_end
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_extra_info_input_blocks
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_extra_info_involuntary_context_switches
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_extra_info_maximum_resident_set_kb
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_extra_info_output_blocks
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_extra_info_page_faults
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_extra_info_page_reclaims
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_extra_info_system_time_us
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_extra_info_user_time_us
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_extra_info_voluntary_context_switches
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_flowControl_enabled
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_flowControl_isLagged
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_flowControl_isLaggedCount
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_flowControl_isLaggedTimeMicros
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_flowControl_locksPerOp
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_flowControl_sustainerRate
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_flowControl_targetRateLimit
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_flowControl_timeAcquiringMicros
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_globalLock_activeClients_readers
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_globalLock_activeClients_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_globalLock_activeClients_writers
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_globalLock_currentQueue
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: count_type
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_globalLock_totalTime
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_localTime
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_locks_Collection_acquireCount_R
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_locks_Collection_acquireCount_W
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_locks_Collection_acquireCount_r
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_locks_Collection_acquireCount_w
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_locks_Database_acquireCount_W
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_locks_Database_acquireCount_r
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_locks_Database_acquireCount_w
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_locks_Database_acquireWaitCount_W
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_locks_Database_acquireWaitCount_r
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_locks_Database_timeAcquiringMicros_W
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_locks_Database_timeAcquiringMicros_r
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_locks_Global_acquireCount_R
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_locks_Global_acquireCount_W
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_locks_Global_acquireCount_r
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_locks_Global_acquireCount_w
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_locks_Global_acquireWaitCount_W
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_locks_Global_acquireWaitCount_r
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_locks_Global_acquireWaitCount_w
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_locks_Global_timeAcquiringMicros_W
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_locks_Global_timeAcquiringMicros_r
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_locks_Global_timeAcquiringMicros_w
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_locks_Mutex_acquireCount_W
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_locks_Mutex_acquireCount_r
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_locks_ParallelBatchWriterMode_acquireCount_r
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_locks_ReplicationStateTransition_acquireCount_W
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_locks_ReplicationStateTransition_acquireCount_w
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_locks_ReplicationStateTransition_acquireWaitCount_w
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_locks_ReplicationStateTransition_timeAcquiringMicros_w
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_locks_acquireCount
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: resource
+            type: string
+          - name: lock_mode
+            type: string
+      - name: mongodb_ss_locks_acquireWaitCount
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: lock_mode
+            type: string
+          - name: resource
+            type: string
+      - name: mongodb_ss_locks_oplog_acquireCount_W
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_locks_oplog_acquireCount_r
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_locks_oplog_acquireCount_w
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_locks_timeAcquiringMicros
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: lock_mode
+            type: string
+          - name: resource
+            type: string
+      - name: mongodb_ss_logicalSessionRecordCache_activeSessionsCount
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_logicalSessionRecordCache_lastSessionsCollectionJobCursorsClosed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_logicalSessionRecordCache_lastSessionsCollectionJobDurationMillis
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_logicalSessionRecordCache_lastSessionsCollectionJobEntriesEnded
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_logicalSessionRecordCache_lastSessionsCollectionJobEntriesRefreshed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_logicalSessionRecordCache_lastSessionsCollectionJobTimestamp
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_logicalSessionRecordCache_lastTransactionReaperJobDurationMillis
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_logicalSessionRecordCache_lastTransactionReaperJobEntriesCleanedUp
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_logicalSessionRecordCache_lastTransactionReaperJobTimestamp
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_logicalSessionRecordCache_sessionCatalogSize
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_logicalSessionRecordCache_sessionsCollectionJobCount
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_logicalSessionRecordCache_transactionReaperJobCount
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_mem_bits
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_mem_resident
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_mem_supported
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_mem_virtual
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_addFields
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_bucket
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_bucketAuto
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_changeStream
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_collStats
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_currentOp
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_facet
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_geoNear
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_graphLookup
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_group
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_indexStats
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_internalApplyOplogUpdate
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_internalInhibitOptimization
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_internalSplitPipeline
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_limit
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_listLocalSessions
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_listSessions
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_lookup
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_match
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_merge
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_mergeCursors
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_out
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_planCacheStats
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_project
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_redact
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_replaceRoot
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_replaceWith
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_sample
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_set
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_skip
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_sort
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_sortByCount
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_unset
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_aggStageCounters_unwind
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: cmd_name
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_abortTransaction_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_abortTransaction_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_addShard_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_addShard_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_aggregate_allowDiskUseTrue
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_aggregate_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_aggregate_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_appendOplogNote_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_appendOplogNote_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_applyOps_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_applyOps_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_authenticate_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_authenticate_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_autoSplitVector_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_autoSplitVector_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_availableQueryOptions_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_availableQueryOptions_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_buildInfo_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_buildInfo_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_checkShardingIndex_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_checkShardingIndex_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_cleanupOrphaned_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_cleanupOrphaned_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_cloneCatalogData_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_cloneCatalogData_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_cloneCollectionAsCapped_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_cloneCollectionAsCapped_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_cloneCollectionOptionsFromPrimaryShard_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_cloneCollectionOptionsFromPrimaryShard_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_cloneCollection_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_cloneCollection_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_collMod_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_collMod_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_collStats_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_collStats_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_commitTransaction_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_commitTransaction_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_compact_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_compact_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrAddShardToZone_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrAddShardToZone_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrAddShard_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrAddShard_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrBalancerStart_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrBalancerStart_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrBalancerStatus_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrBalancerStatus_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrBalancerStop_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrBalancerStop_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrClearJumboFlag_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrClearJumboFlag_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrCommitChunkMerge_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrCommitChunkMerge_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrCommitChunkMigration_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrCommitChunkMigration_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrCommitChunkSplit_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrCommitChunkSplit_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrCommitChunksMerge_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrCommitChunksMerge_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrCommitMovePrimary_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrCommitMovePrimary_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrCreateCollection_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrCreateCollection_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrCreateDatabase_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrCreateDatabase_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrDropCollection_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrDropCollection_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrDropDatabase_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrDropDatabase_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrEnableSharding_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrEnableSharding_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrMoveChunk_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrMoveChunk_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrMovePrimary_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrMovePrimary_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrRemoveShardFromZone_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrRemoveShardFromZone_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrRemoveShard_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrRemoveShard_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrRepairShardedCollectionChunksHistory_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrRepairShardedCollectionChunksHistory_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrShardCollection_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrShardCollection_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrUpdateZoneKeyRange_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_configsvrUpdateZoneKeyRange_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_connPoolStats_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_connPoolStats_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_connPoolSync_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_connPoolSync_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_connectionStatus_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_connectionStatus_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_convertToCapped_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_convertToCapped_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_coordinateCommitTransaction_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_coordinateCommitTransaction_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_count_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_count_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_createIndexes_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_createIndexes_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_createRole_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_createRole_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_createUser_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_createUser_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_create_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_create_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_currentOp_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_currentOp_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_dataSize_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_dataSize_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_dbHash_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_dbHash_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_dbStats_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_dbStats_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_delete_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_delete_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_distinct_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_distinct_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_driverOIDTest_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_driverOIDTest_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_dropAllRolesFromDatabase_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_dropAllRolesFromDatabase_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_dropAllUsersFromDatabase_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_dropAllUsersFromDatabase_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_dropConnections_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_dropConnections_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_dropDatabase_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_dropDatabase_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_dropIndexes_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_dropIndexes_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_dropRole_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_dropRole_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_dropUser_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_dropUser_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_drop_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_drop_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_endSessions_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_endSessions_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_explain_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_explain_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_features_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_features_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_filemd5_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_filemd5_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_findAndModify_arrayFilters
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_findAndModify_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_findAndModify_pipeline
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_findAndModify_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_find_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_find_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_flushDatabaseCacheUpdates_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_flushDatabaseCacheUpdates_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_flushRouterConfig_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_flushRouterConfig_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_flushRoutingTableCacheUpdates_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_flushRoutingTableCacheUpdates_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_fsyncUnlock_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_fsyncUnlock_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_fsync_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_fsync_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_geoSearch_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_geoSearch_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_getCmdLineOpts_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_getCmdLineOpts_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_getDatabaseVersion_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_getDatabaseVersion_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_getDiagnosticData_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_getDiagnosticData_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_getFreeMonitoringStatus_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_getFreeMonitoringStatus_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_getLastError_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_getLastError_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_getLog_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_getLog_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_getMore_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_getMore_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_getNextSessionMods_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_getNextSessionMods_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_getParameter_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_getParameter_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_getShardMap_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_getShardMap_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_getShardVersion_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_getShardVersion_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_getUserCacheGeneration_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_getUserCacheGeneration_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_getnonce_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_getnonce_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_grantPrivilegesToRole_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_grantPrivilegesToRole_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_grantRolesToRole_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_grantRolesToRole_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_grantRolesToUser_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_grantRolesToUser_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_hello_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_hello_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_hostInfo_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_hostInfo_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_insert_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_insert_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_invalidateUserCache_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_invalidateUserCache_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_isMaster_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_isMaster_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_isSelf_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_isSelf_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_killAllSessionsByPattern_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_killAllSessionsByPattern_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_killAllSessions_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_killAllSessions_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_killCursors_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_killCursors_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_killOp_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_killOp_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_killSessions_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_killSessions_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_listCollections_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_listCollections_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_listCommands_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_listCommands_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_listDatabases_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_listDatabases_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_listIndexes_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_listIndexes_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_lockInfo_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_lockInfo_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_logRotate_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_logRotate_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_logout_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_logout_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_mapReduce_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_mapReduce_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_mapreduce_shardedfinish_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_mapreduce_shardedfinish_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_mergeAuthzCollections_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_mergeAuthzCollections_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_mergeChunks_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_mergeChunks_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_migrateClone_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_migrateClone_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_moveChunk_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_moveChunk_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_movePrimary_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_movePrimary_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_ping_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_ping_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_planCacheClearFilters_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_planCacheClearFilters_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_planCacheClear_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_planCacheClear_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_planCacheListFilters_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_planCacheListFilters_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_planCacheListPlans_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_planCacheListPlans_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_planCacheListQueryShapes_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_planCacheListQueryShapes_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_planCacheSetFilter_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_planCacheSetFilter_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_prepareTransaction_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_prepareTransaction_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_profile_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_profile_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_reIndex_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_reIndex_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_recvChunkAbort_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_recvChunkAbort_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_recvChunkCommit_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_recvChunkCommit_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_recvChunkStart_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_recvChunkStart_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_recvChunkStatus_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_recvChunkStatus_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_refreshSessions_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_refreshSessions_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_renameCollection_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_renameCollection_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_repairCursor_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_repairCursor_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_repairDatabase_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_repairDatabase_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetAbortPrimaryCatchUp_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetAbortPrimaryCatchUp_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetFreeze_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetFreeze_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetGetConfig_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetGetConfig_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetGetRBID_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetGetRBID_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetGetStatus_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetGetStatus_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetHeartbeat_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetHeartbeat_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetInitiate_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetInitiate_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetMaintenance_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetMaintenance_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetReconfig_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetReconfig_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetRequestVotes_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetRequestVotes_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetResizeOplog_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetResizeOplog_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetStepDownWithForce_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetStepDownWithForce_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetStepDown_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetStepDown_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetStepUp_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetStepUp_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetSyncFrom_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetSyncFrom_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetUpdatePosition_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_replSetUpdatePosition_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_resetError_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_resetError_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_revokePrivilegesFromRole_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_revokePrivilegesFromRole_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_revokeRolesFromRole_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_revokeRolesFromRole_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_revokeRolesFromUser_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_revokeRolesFromUser_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_rolesInfo_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_rolesInfo_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_saslContinue_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_saslContinue_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_saslStart_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_saslStart_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_serverStatus_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_serverStatus_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_setFeatureCompatibilityVersion_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_setFeatureCompatibilityVersion_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_setFreeMonitoring_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_setFreeMonitoring_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_setParameter_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_setParameter_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_setShardVersion_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_setShardVersion_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_shardConnPoolStats_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_shardConnPoolStats_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_shardingState_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_shardingState_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_shardsvrSetAllowMigrations_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_shardsvrSetAllowMigrations_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_shardsvrShardCollection_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_shardsvrShardCollection_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_shutdown_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_shutdown_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_splitChunk_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_splitChunk_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_splitVector_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_splitVector_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_startRecordingTraffic_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_startRecordingTraffic_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_startSession_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_startSession_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_stopRecordingTraffic_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_stopRecordingTraffic_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_top_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_top_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_touch_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_touch_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_transferMods_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_transferMods_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_unsetSharding_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_unsetSharding_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_updateRole_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_updateRole_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_updateUser_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_updateUser_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_update_arrayFilters
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_update_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_update_pipeline
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_update_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_commands_usersInfo_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_usersInfo_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_validate_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_validate_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_voteCommitIndexBuild_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_commands_voteCommitIndexBuild_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_waitForFailPoint_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_commands_waitForFailPoint_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_whatsmyuri_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_commands_whatsmyuri_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_cursor_open
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: csr_type
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_cursor_timedOut
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_document
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: doc_op_type
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_getLastError_wtime_num
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_getLastError_wtime_totalMillis
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_getLastError_wtimeouts
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_operation_scanAndOrder
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_operation_writeConflicts
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_all
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_alwaysFalse
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_alwaysTrue
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_and
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_bitsAllClear
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_bitsAllSet
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_bitsAnyClear
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_bitsAnySet
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_comment
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_elemMatch
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_eq
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_exists
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_expr
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_geoIntersects
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_geoWithin
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_gt
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_gte
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_in
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_jsonSchema
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_lt
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_lte
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_mod
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_ne
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_near
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_nearSphere
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_nin
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_nor
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_not
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_or
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_regex
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_size
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_text
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_type
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_operatorCounters_match_where
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_queryExecutor_scanned
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_queryExecutor_scannedObjects
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_query_planCacheTotalSizeEstimateBytes
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_query_updateOneOpStyleBroadcastWithExactIDCount
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_record_moves
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_repl_apply_attemptsToBecomeSecondary
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_repl_apply_batchSize
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_repl_apply_batches_num
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_repl_apply_batches_totalMillis
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_repl_apply_ops
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_repl_buffer_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_repl_buffer_maxSizeBytes
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_repl_buffer_sizeBytes
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_repl_executor_pool_inProgressCount
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_repl_executor_queues_networkInProgress
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_repl_executor_queues_sleepers
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_repl_executor_shuttingDown
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_repl_executor_unsignaledEvents
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_repl_initialSync_completed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_repl_initialSync_failedAttempts
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_repl_initialSync_failures
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_repl_network_bytes
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_repl_network_getmores_num
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_repl_network_getmores_totalMillis
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_repl_network_notPrimaryLegacyUnacknowledgedWrites
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_repl_network_notPrimaryUnacknowledgedWrites
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_metrics_repl_network_ops
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_repl_network_readersCreated
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_repl_network_replSetUpdatePosition_num
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_repl_stateTransition_userOperationsKilled
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_repl_stateTransition_userOperationsRunning
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_repl_syncSource_numSelections
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_repl_syncSource_numTimesChoseDifferent
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_repl_syncSource_numTimesChoseSame
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_metrics_repl_syncSource_numTimesCouldNotFind
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_metrics_ttl_deletedDocuments
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_metrics_ttl_passes
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_network_bytesIn
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_network_bytesOut
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_network_compression_snappy_compressor_bytesIn
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_network_compression_snappy_compressor_bytesOut
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_network_compression_snappy_decompressor_bytesIn
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_network_compression_snappy_decompressor_bytesOut
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_network_compression_zlib_compressor_bytesIn
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_network_compression_zlib_compressor_bytesOut
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_network_compression_zlib_decompressor_bytesIn
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_network_compression_zlib_decompressor_bytesOut
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_network_compression_zstd_compressor_bytesIn
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_network_compression_zstd_compressor_bytesOut
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_network_compression_zstd_decompressor_bytesIn
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_network_compression_zstd_decompressor_bytesOut
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_network_numRequests
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_network_physicalBytesIn
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_network_physicalBytesOut
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_network_serviceExecutorTaskStats_threadsRunning
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_ok
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_opLatencies_latency
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: op_type
+            type: string
+      - name: mongodb_ss_opLatencies_ops
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: op_type
+            type: string
+      - name: mongodb_ss_opReadConcernCounters
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: concern_type
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_opcounters
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: legacy_op_type
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_opcountersRepl
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: legacy_op_type
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_oplogTruncation_totalTimeProcessingMicros
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_oplogTruncation_totalTimeTruncatingMicros
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_oplogTruncation_truncateCount
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_pid
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_repl_ismaster
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_repl_lastWrite_lastWriteDate
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_repl_lastWrite_majorityOpTime_t
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_repl_lastWrite_majorityWriteDate
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_repl_lastWrite_opTime_t
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_repl_rbid
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_repl_secondary
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_repl_setVersion
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_scramCache_SCRAM_SHA_1_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_scramCache_SCRAM_SHA_1_hits
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_scramCache_SCRAM_SHA_1_misses
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_scramCache_SCRAM_SHA_256_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_scramCache_SCRAM_SHA_256_hits
+        type: counter
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_scramCache_SCRAM_SHA_256_misses
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_shardingStatistics_catalogCache_countFailedRefreshes
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_shardingStatistics_catalogCache_countFullRefreshesStarted
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_shardingStatistics_catalogCache_countIncrementalRefreshesStarted
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_shardingStatistics_catalogCache_countStaleConfigErrors
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_shardingStatistics_catalogCache_numActiveFullRefreshes
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_shardingStatistics_catalogCache_numActiveIncrementalRefreshes
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_shardingStatistics_catalogCache_numCollectionEntries
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_shardingStatistics_catalogCache_numDatabaseEntries
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_shardingStatistics_catalogCache_operationsBlockedByRefresh_countAllOperations
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_shardingStatistics_catalogCache_operationsBlockedByRefresh_countCommands
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_shardingStatistics_catalogCache_operationsBlockedByRefresh_countDeletes
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_shardingStatistics_catalogCache_operationsBlockedByRefresh_countInserts
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_shardingStatistics_catalogCache_operationsBlockedByRefresh_countQueries
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_shardingStatistics_catalogCache_operationsBlockedByRefresh_countUpdates
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_shardingStatistics_catalogCache_totalRefreshWaitTimeMicros
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_shardingStatistics_countDocsClonedOnDonor
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_shardingStatistics_countDocsClonedOnRecipient
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_shardingStatistics_countDocsDeletedOnDonor
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_shardingStatistics_countDonorMoveChunkLockTimeout
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_shardingStatistics_countDonorMoveChunkStarted
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_shardingStatistics_countRecipientMoveChunkStarted
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_shardingStatistics_countStaleConfigErrors
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_shardingStatistics_totalCriticalSectionCommitTimeMillis
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_shardingStatistics_totalCriticalSectionTimeMillis
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_shardingStatistics_totalDonorChunkCloneTimeMillis
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_start
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_storageEngine_backupCursorOpen
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_storageEngine_dropPendingIdents
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_storageEngine_persistent
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_storageEngine_readOnly
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_storageEngine_supportsCommittedReads
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_storageEngine_supportsPendingDrops
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_storageEngine_supportsSnapshotReadConcern
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_tcmalloc_generic_current_allocated_bytes
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_tcmalloc_generic_heap_size
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_tcmalloc_tcmalloc_aggressive_memory_decommit
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_tcmalloc_tcmalloc_central_cache_free_bytes
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_tcmalloc_tcmalloc_current_total_thread_cache_bytes
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_tcmalloc_tcmalloc_max_total_thread_cache_bytes
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_tcmalloc_tcmalloc_pageheap_commit_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_tcmalloc_tcmalloc_pageheap_committed_bytes
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_tcmalloc_tcmalloc_pageheap_decommit_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_tcmalloc_tcmalloc_pageheap_free_bytes
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_tcmalloc_tcmalloc_pageheap_reserve_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_tcmalloc_tcmalloc_pageheap_scavenge_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_tcmalloc_tcmalloc_pageheap_total_commit_bytes
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_tcmalloc_tcmalloc_pageheap_total_decommit_bytes
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_tcmalloc_tcmalloc_pageheap_total_reserve_bytes
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_tcmalloc_tcmalloc_pageheap_unmapped_bytes
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_tcmalloc_tcmalloc_release_rate
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_tcmalloc_tcmalloc_spinlock_total_delay_ns
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_tcmalloc_tcmalloc_thread_cache_free_bytes
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_tcmalloc_tcmalloc_total_free_bytes
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_tcmalloc_tcmalloc_transfer_cache_free_bytes
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_trafficRecording_running
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_transactions_currentActive
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_transactions_currentInactive
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_transactions_currentOpen
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_transactions_currentPrepared
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_transactions_retriedCommandsCount
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_transactions_retriedStatementsCount
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_transactions_totalAborted
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_transactions_totalCommitted
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_transactions_totalPrepared
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_transactions_totalPreparedThenAborted
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_transactions_totalPreparedThenCommitted
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_transactions_totalStarted
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_transactions_transactionsCollectionWriteCount
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_transportSecurity_1_0
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_transportSecurity_1_1
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_transportSecurity_1_2
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_transportSecurity_1_3
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_transportSecurity_unknown
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_twoPhaseCommitCoordinator_currentInSteps_deletingCoordinatorDoc
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_twoPhaseCommitCoordinator_currentInSteps_waitingForDecisionAcks
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_twoPhaseCommitCoordinator_currentInSteps_waitingForVotes
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_twoPhaseCommitCoordinator_currentInSteps_writingDecision
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_twoPhaseCommitCoordinator_currentInSteps_writingParticipantList
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_twoPhaseCommitCoordinator_totalAbortedTwoPhaseCommit
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_twoPhaseCommitCoordinator_totalCommittedTwoPhaseCommit
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_twoPhaseCommitCoordinator_totalCreated
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_twoPhaseCommitCoordinator_totalStartedTwoPhaseCommit
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_uptime
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_uptimeEstimate
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_uptimeMillis
+        type: count
+        defaultResolution: 15
+        unit: milliseconds
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_async_current_work_queue_length
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_async_maximum_work_queue_length
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_async_number_of_allocation_state_races
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_async_number_of_flush_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_async_number_of_operation_slots_viewed_for_allocation
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_async_number_of_times_operation_allocation_failed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_async_number_of_times_worker_found_no_work
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_async_total_allocations
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_async_total_compact_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_async_total_insert_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_async_total_remove_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_async_total_search_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_async_total_update_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_block_manager_blocks_pre_loaded
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_block_manager_blocks_read
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_block_manager_blocks_written
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_block_manager_bytes_read
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_block_manager_bytes_written
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_block_manager_bytes_written_for_checkpoint
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_block_manager_mapped_blocks_read
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_block_manager_mapped_bytes_read
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_application_threads_page_read_from_disk_to_cache_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_cache_application_threads_page_read_from_disk_to_cache_time_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_application_threads_page_write_from_cache_to_disk_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_cache_application_threads_page_write_from_cache_to_disk_time_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_cache_bytes_belonging_to_page_images_in_the_cache
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_bytes_belonging_to_the_cache_overflow_table_in_the_cache
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_bytes_currently_in_the_cache
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_bytes_dirty_in_the_cache_cumulative
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_bytes_not_belonging_to_page_images_in_the_cache
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_cache_bytes_read_into_cache
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_bytes_written_from_cache
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_cache_overflow_cursor_application_thread_wait_time_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_cache_overflow_cursor_internal_thread_wait_time_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_cache_cache_overflow_score
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_cache_overflow_table_entries
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_cache_cache_overflow_table_insert_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_cache_cache_overflow_table_max_on_disk_size
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_cache_overflow_table_on_disk_size
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_cache_overflow_table_remove_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_checkpoint_blocked_page_eviction
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_calls_to_get_a_page
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_calls_to_get_a_page_found_queue_empty
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_calls_to_get_a_page_found_queue_empty_after_locking
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_currently_operating_in_aggressive_mode
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_empty_score
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_passes_of_a_file
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_server_candidate_queue_empty_when_topping_up
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_server_candidate_queue_not_empty_when_topping_up
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_server_evicting_pages
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_server_slept_because_we_did_not_make_progress_with_eviction
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_server_unable_to_reach_eviction_goal
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_server_waiting_for_a_leaf_page
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_state
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_walk_most_recent_sleeps_for_checkpoint_handle_gathering
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_walk_target_pages_histogram_0_9
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_walk_target_pages_histogram_10_31
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_walk_target_pages_histogram_128_and_higher
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_walk_target_pages_histogram_32_63
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_walk_target_pages_histogram_64_128
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_walk_target_strategy_both_clean_and_dirty_pages
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_walk_target_strategy_only_clean_pages
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_walk_target_strategy_only_dirty_pages
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_walks_abandoned
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_walks_gave_up_because_they_restarted_their_walk_twice
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_walks_gave_up_because_they_saw_too_many_pages_and_found_no_candidates
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_walks_gave_up_because_they_saw_too_many_pages_and_found_too_few_candidates
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_walks_reached_end_of_tree
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_walks_started_from_root_of_tree
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_walks_started_from_saved_location_in_tree
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_worker_thread_active
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_worker_thread_created
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_worker_thread_evicting_pages
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_worker_thread_removed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_eviction_worker_thread_stable_number
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_cache_files_with_active_eviction_walks
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_files_with_new_eviction_walks_started
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_cache_force_re_tuning_of_eviction_workers_once_in_a_while
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_forced_eviction_pages_evicted_that_were_clean_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_forced_eviction_pages_evicted_that_were_clean_time_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_forced_eviction_pages_evicted_that_were_dirty_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_cache_forced_eviction_pages_evicted_that_were_dirty_time_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_cache_forced_eviction_pages_selected_because_of_too_many_deleted_items_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_forced_eviction_pages_selected_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_forced_eviction_pages_selected_unable_to_be_evicted_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_forced_eviction_pages_selected_unable_to_be_evicted_time
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_cache_hazard_pointer_blocked_page_eviction
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_cache_hazard_pointer_check_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_cache_hazard_pointer_check_entries_walked
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_hazard_pointer_maximum_array_length
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_cache_in_memory_page_passed_criteria_to_be_split
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_in_memory_page_splits
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_cache_internal_pages_evicted
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_cache_internal_pages_queued_for_eviction
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_internal_pages_seen_by_eviction_walk
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_internal_pages_seen_by_eviction_walk_that_are_already_queued
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_internal_pages_split_during_eviction
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_leaf_pages_split_during_eviction
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_cache_maximum_bytes_configured
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_maximum_page_size_at_eviction
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_modified_pages_evicted
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_cache_modified_pages_evicted_by_application_threads
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_cache_operations_timed_out_waiting_for_space_in_cache
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_overflow_pages_read_into_cache
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_page_split_during_eviction_deepened_the_tree
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_page_written_requiring_cache_overflow_records
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_pages_currently_held_in_the_cache
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_cache_pages_evicted_by_application_threads
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_pages_queued_for_eviction
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_pages_queued_for_eviction_post_lru_sorting
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_pages_queued_for_urgent_eviction
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_pages_queued_for_urgent_eviction_during_walk
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_cache_pages_read_into_cache
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_pages_read_into_cache_after_truncate
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_pages_read_into_cache_after_truncate_in_prepare_state
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_pages_read_into_cache_requiring_cache_overflow_entries
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_pages_read_into_cache_requiring_cache_overflow_for_checkpoint
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_pages_read_into_cache_skipping_older_cache_overflow_entries
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_pages_read_into_cache_with_skipped_cache_overflow_entries_needed_later
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_pages_read_into_cache_with_skipped_cache_overflow_entries_needed_later_by_checkpoint
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_pages_requested_from_the_cache
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_pages_seen_by_eviction_walk
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_pages_seen_by_eviction_walk_that_are_already_queued
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_cache_pages_selected_for_eviction_unable_to_be_evicted
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_pages_selected_for_eviction_unable_to_be_evicted_as_the_parent_page_has_overflow_items
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_pages_selected_for_eviction_unable_to_be_evicted_because_of_active_children_on_an_internal_page
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_pages_selected_for_eviction_unable_to_be_evicted_because_of_failure_in_reconciliation
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_pages_selected_for_eviction_unable_to_be_evicted_due_to_newer_modifications_on_a_clean_page
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_pages_walked_for_eviction
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_cache_pages_written_from_cache
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_pages_written_requiring_in_memory_restoration
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_percentage_overhead
+        type: gauge
+        defaultResolution: 15
+        unit: percent
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_tracked_bytes_belonging_to_internal_pages_in_the_cache
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_tracked_bytes_belonging_to_leaf_pages_in_the_cache
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_tracked_dirty_bytes_in_the_cache
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_tracked_dirty_pages_in_the_cache
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cache_unmodified_pages_evicted
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_capacity_background_fsync_file_handles_considered
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_capacity_background_fsync_file_handles_synced
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_capacity_background_fsync_time_msecs
+        type: gauge
+        defaultResolution: 15
+        unit: milliseconds
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_capacity_bytes_read
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_capacity_bytes_written_for_checkpoint
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_capacity_bytes_written_for_eviction
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_capacity_bytes_written_for_log
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_capacity_bytes_written_total
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_capacity_threshold_to_call_fsync
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_capacity_time_waiting_due_to_total_capacity_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_capacity_time_waiting_during_checkpoint_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_capacity_time_waiting_during_eviction_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_capacity_time_waiting_during_logging_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_capacity_time_waiting_during_read_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_concurrentTransactions_available
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: txn_rw
+            type: string
+      - name: mongodb_ss_wt_concurrentTransactions_out
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: txn_rw
+            type: string
+      - name: mongodb_ss_wt_concurrentTransactions_totalTickets
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: txn_rw
+            type: string
+      - name: mongodb_ss_wt_connection_auto_adjusting_condition_resets
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_connection_auto_adjusting_condition_wait_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_connection_detected_system_time_went_backwards
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_connection_files_currently_open
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_connection_hash_bucket_array_size_for_data_handles
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_connection_hash_bucket_array_size_general
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_connection_memory_allocations
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_connection_memory_frees
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_connection_memory_re_allocations
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_connection_pthread_mutex_condition_wait_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_connection_pthread_mutex_shared_lock_read_lock_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_connection_pthread_mutex_shared_lock_write_lock_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_connection_total_fsync_I_Os
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_connection_total_read_I_Os
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_connection_total_write_I_Os
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_cursor_cached_cursor_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cursor_cursor_bulk_loaded_cursor_insert_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cursor_cursor_close_calls_that_result_in_cache
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_cursor_cursor_create_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_cursor_cursor_insert_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cursor_cursor_insert_key_and_value_bytes
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cursor_cursor_modify_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cursor_cursor_modify_key_and_value_bytes_affected
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cursor_cursor_modify_value_bytes_modified
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_cursor_cursor_next_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cursor_cursor_operation_restarted
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cursor_cursor_prev_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cursor_cursor_remove_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_cursor_cursor_remove_key_bytes_removed
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cursor_cursor_reserve_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_cursor_cursor_reset_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cursor_cursor_search_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cursor_cursor_search_near_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cursor_cursor_sweep_buckets
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cursor_cursor_sweep_cursors_closed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cursor_cursor_sweep_cursors_examined
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_cursor_cursor_sweeps
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_cursor_cursor_truncate_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cursor_cursor_update_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cursor_cursor_update_key_and_value_bytes
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_cursor_cursor_update_value_size_change
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cursor_cursors_reused_from_cache
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_cursor_open_cursor_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_data_handle_connection_data_handle_size
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_data_handle_connection_data_handles_currently_active
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_data_handle_connection_sweep_candidate_became_referenced
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_data_handle_connection_sweep_dhandles_closed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_data_handle_connection_sweep_dhandles_removed_from_hash_list
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_data_handle_connection_sweep_time_of_death_sets
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_data_handle_connection_sweeps
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_data_handle_connection_sweeps_skipped_due_to_checkpoint_gathering_handles
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_data_handle_session_dhandles_swept
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_data_handle_session_sweep_attempts
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_lock_checkpoint_lock_acquisitions
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_lock_checkpoint_lock_application_thread_wait_time_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_lock_checkpoint_lock_internal_thread_wait_time_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_lock_dhandle_lock_application_thread_time_waiting_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_lock_dhandle_lock_internal_thread_time_waiting_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_lock_dhandle_read_lock_acquisitions
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_lock_dhandle_write_lock_acquisitions
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_lock_durable_timestamp_queue_lock_application_thread_time_waiting_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_lock_durable_timestamp_queue_lock_internal_thread_time_waiting_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_lock_durable_timestamp_queue_read_lock_acquisitions
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_lock_durable_timestamp_queue_write_lock_acquisitions
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_lock_metadata_lock_acquisitions
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_lock_metadata_lock_application_thread_wait_time_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_lock_metadata_lock_internal_thread_wait_time_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_lock_read_timestamp_queue_lock_application_thread_time_waiting_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_lock_read_timestamp_queue_lock_internal_thread_time_waiting_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_lock_read_timestamp_queue_read_lock_acquisitions
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_lock_read_timestamp_queue_write_lock_acquisitions
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_lock_schema_lock_acquisitions
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_lock_schema_lock_application_thread_wait_time_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_lock_schema_lock_internal_thread_wait_time_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_lock_table_lock_application_thread_time_waiting_for_the_table_lock_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_lock_table_lock_internal_thread_time_waiting_for_the_table_lock_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_lock_table_read_lock_acquisitions
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_lock_table_write_lock_acquisitions
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_lock_txn_global_lock_application_thread_time_waiting_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_lock_txn_global_lock_internal_thread_time_waiting_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_lock_txn_global_read_lock_acquisitions
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_lock_txn_global_write_lock_acquisitions
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_log_busy_returns_attempting_to_switch_slots
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_force_archive_time_sleeping_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_log_log_bytes_of_payload_data
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_log_log_bytes_written
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_log_files_manually_zero_filled
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_log_flush_operations
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_log_force_write_operations
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_log_force_write_operations_skipped
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_log_records_compressed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_log_records_not_compressed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_log_records_too_small_to_compress
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_log_log_release_advances_write_LSN
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_log_scan_operations
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_log_log_scan_records_requiring_two_reads
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_log_server_thread_advances_write_LSN
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_log_server_thread_write_LSN_walk_skipped
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_log_sync_dir_operations
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_log_sync_dir_time_duration_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_log_log_sync_operations
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_log_sync_time_duration_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_log_log_write_operations
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_logging_bytes_consolidated
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_maximum_log_file_size
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_log_number_of_pre_allocated_log_files_to_create
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_pre_allocated_log_files_not_ready_and_missed
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_pre_allocated_log_files_prepared
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_log_pre_allocated_log_files_used
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_records_processed_by_log_scan
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_log_slot_close_lost_race
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_slot_close_unbuffered_waits
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_log_slot_closures
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_slot_join_atomic_update_races
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_slot_join_calls_atomic_updates_raced
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_log_slot_join_calls_did_not_yield
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_log_slot_join_calls_found_active_slot_closed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_log_slot_join_calls_slept
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_slot_join_calls_yielded
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_log_slot_join_found_active_slot_closed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_slot_joins_yield_time_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_slot_transitions_unable_to_find_free_slot
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_slot_unbuffered_writes
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_total_in_memory_size_of_compressed_records
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_log_total_log_buffer_size
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_total_size_of_compressed_records
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_written_slots_coalesced
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_log_yields_waiting_for_previous_log_file_close
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_perf
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: perf_bucket
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_reconciliation_fast_path_pages_deleted
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_reconciliation_page_reconciliation_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_reconciliation_page_reconciliation_calls_for_eviction
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_reconciliation_pages_deleted
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_reconciliation_split_bytes_currently_awaiting_free
+        type: gauge
+        defaultResolution: 15
+        unit: bytes
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_reconciliation_split_objects_currently_awaiting_free
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_session_open_session_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_session_session_query_timestamp_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_session_table_alter_failed_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_session_table_alter_successful_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_session_table_alter_unchanged_and_skipped
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_session_table_compact_failed_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_session_table_compact_successful_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_session_table_create_failed_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_session_table_create_successful_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_session_table_drop_failed_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_session_table_drop_successful_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_session_table_import_failed_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_session_table_import_successful_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_session_table_rebalance_failed_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_session_table_rebalance_successful_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_session_table_rename_failed_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_session_table_rename_successful_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_session_table_salvage_failed_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_session_table_salvage_successful_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_session_table_truncate_failed_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_session_table_truncate_successful_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_session_table_verify_failed_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_session_table_verify_successful_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_snapshot_window_settings_cache_pressure_percentage_threshold
+        type: gauge
+        defaultResolution: 15
+        unit: percent
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_snapshot_window_settings_current_available_snapshots_window_size_in_seconds
+        type: gauge
+        defaultResolution: 15
+        unit: seconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_snapshot_window_settings_current_cache_pressure_percentage
+        type: gauge
+        defaultResolution: 15
+        unit: percent
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_snapshot_window_settings_max_target_available_snapshots_window_size_in_seconds
+        type: gauge
+        defaultResolution: 15
+        unit: seconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_snapshot_window_settings_target_available_snapshots_window_size_in_seconds
+        type: gauge
+        defaultResolution: 15
+        unit: seconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_snapshot_window_settings_total_number_of_SnapshotTooOld_errors
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_thread_state_active_filesystem_fsync_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_thread_state_active_filesystem_read_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_thread_state_active_filesystem_write_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_thread_yield_application_thread_time_evicting_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_thread_yield_application_thread_time_waiting_for_cache_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_thread_yield_connection_close_blocked_waiting_for_transaction_state_stabilization
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_thread_yield_connection_close_yielded_for_lsm_manager_shutdown
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_thread_yield_data_handle_lock_yielded
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_thread_yield_get_reference_for_page_index_and_slot_time_sleeping_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_thread_yield_log_server_sync_yielded_for_log_write
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_thread_yield_page_access_yielded_due_to_prepare_state_change
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_thread_yield_page_acquire_busy_blocked
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_thread_yield_page_acquire_eviction_blocked
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_thread_yield_page_acquire_locked_blocked
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_thread_yield_page_acquire_read_blocked
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_thread_yield_page_acquire_time_sleeping_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_thread_yield_page_delete_rollback_time_sleeping_for_state_change_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_thread_yield_page_reconciliation_yielded_due_to_child_modification
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_txn_Number_of_prepared_updates
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_txn_Number_of_prepared_updates_added_to_cache_overflow
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_durable_timestamp_queue_entries_walked
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_txn_durable_timestamp_queue_insert_to_empty
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_durable_timestamp_queue_inserts_to_head
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_txn_durable_timestamp_queue_inserts_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_durable_timestamp_queue_length
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_number_of_named_snapshots_created
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_txn_number_of_named_snapshots_dropped
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_prepared_transactions
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_txn_prepared_transactions_committed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_txn_prepared_transactions_currently_active
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_prepared_transactions_rolled_back
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_query_timestamp_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_txn_read_timestamp_queue_entries_walked
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_txn_read_timestamp_queue_insert_to_empty
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_txn_read_timestamp_queue_inserts_to_head
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_read_timestamp_queue_inserts_total
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_txn_read_timestamp_queue_length
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_rollback_to_stable_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_txn_rollback_to_stable_updates_aborted
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_txn_rollback_to_stable_updates_removed_from_cache_overflow
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_set_timestamp_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_set_timestamp_durable_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_txn_set_timestamp_durable_updates
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_ss_wt_txn_set_timestamp_oldest_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_set_timestamp_oldest_updates
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_txn_set_timestamp_stable_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_set_timestamp_stable_updates
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_begins
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_checkpoint_currently_running
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_checkpoint_generation
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_checkpoint_max_time_msecs
+        type: gauge
+        defaultResolution: 15
+        unit: milliseconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_checkpoint_min_time_msecs
+        type: gauge
+        defaultResolution: 15
+        unit: milliseconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_checkpoint_most_recent_duration_for_gathering_all_handles_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_checkpoint_most_recent_duration_for_gathering_applied_handles_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_checkpoint_most_recent_duration_for_gathering_skipped_handles_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_checkpoint_most_recent_handles_applied
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_checkpoint_most_recent_handles_skipped
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_checkpoint_most_recent_handles_walked
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_checkpoint_most_recent_time_msecs
+        type: gauge
+        defaultResolution: 15
+        unit: milliseconds
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_checkpoint_scrub_dirty_target
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_checkpoint_scrub_time_msecs
+        type: gauge
+        defaultResolution: 15
+        unit: milliseconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_checkpoint_total_time_msecs
+        type: gauge
+        defaultResolution: 15
+        unit: milliseconds
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_checkpoints
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_checkpoints_skipped_because_database_was_clean
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_failures_due_to_cache_overflow
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_fsync_calls_for_checkpoint_after_allocating_the_transaction_ID
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_fsync_duration_for_checkpoint_after_allocating_the_transaction_ID_usecs
+        type: gauge
+        defaultResolution: 15
+        unit: microseconds
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_range_of_IDs_currently_pinned
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_range_of_IDs_currently_pinned_by_a_checkpoint
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_range_of_IDs_currently_pinned_by_named_snapshots
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_range_of_timestamps_currently_pinned
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_range_of_timestamps_pinned_by_a_checkpoint
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_range_of_timestamps_pinned_by_the_oldest_active_read_timestamp
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_range_of_timestamps_pinned_by_the_oldest_timestamp
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_read_timestamp_of_the_oldest_active_reader
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_transaction_sync_calls
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_transactions_committed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_transactions_rolled_back
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_ss_wt_txn_update_conflicts
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_cpu_btime
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_cpu_ctxt
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_cpu_guest_ms
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_cpu_guest_nice_ms
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_cpu_idle_ms
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_cpu_iowait_ms
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_cpu_irq_ms
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_cpu_nice_ms
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_cpu_num_cpus
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_cpu_processes
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_cpu_procs_blocked
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_cpu_procs_running
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_cpu_softirq_ms
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_cpu_steal_ms
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_cpu_system_ms
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_cpu_user_ms
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_disks_vda_io_in_progress
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_disks_vda_io_queued_ms
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_disks_vda_io_time_ms
+        type: gauge
+        defaultResolution: 15
+        unit: milliseconds
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_disks_vda_read_sectors
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_disks_vda_read_time_ms
+        type: gauge
+        defaultResolution: 15
+        unit: milliseconds
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_disks_vda_reads
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_disks_vda_reads_merged
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_disks_vda_write_sectors
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_disks_vda_write_time_ms
+        type: gauge
+        defaultResolution: 15
+        unit: milliseconds
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_disks_vda_writes
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_disks_vda_writes_merged
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_end
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_memory_Active_anon_kb
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_memory_Active_file_kb
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_memory_Active_kb
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_memory_Buffers_kb
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_memory_Cached_kb
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_memory_Dirty_kb
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_memory_Inactive_anon_kb
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_memory_Inactive_file_kb
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_memory_Inactive_kb
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_memory_MemAvailable_kb
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_memory_MemFree_kb
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_memory_MemTotal_kb
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_memory_SwapCached_kb
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_memory_SwapFree_kb
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_memory_SwapTotal_kb
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_mounts_available
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_mounts_capacity
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_mounts_data_configdb_available
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_mounts_data_configdb_capacity
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_mounts_data_configdb_free
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_mounts_data_db_available
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_mounts_data_db_capacity
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_mounts_data_db_free
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_mounts_dev_available
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_mounts_dev_capacity
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_mounts_dev_free
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_mounts_dev_shm_available
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_mounts_dev_shm_capacity
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_mounts_dev_shm_free
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_mounts_etc_hostname_available
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_mounts_etc_hostname_capacity
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_mounts_etc_hostname_free
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_mounts_etc_hosts_available
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_mounts_etc_hosts_capacity
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_mounts_etc_hosts_free
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_mounts_etc_resolv_conf_available
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_mounts_etc_resolv_conf_capacity
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_mounts_etc_resolv_conf_free
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_mounts_free
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_mounts_proc_kcore_available
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_mounts_proc_kcore_capacity
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_mounts_proc_kcore_free
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_mounts_proc_keys_available
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_mounts_proc_keys_capacity
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_mounts_proc_keys_free
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_mounts_proc_sched_debug_available
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_mounts_proc_sched_debug_capacity
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_mounts_proc_sched_debug_free
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_mounts_proc_timer_list_available
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_mounts_proc_timer_list_capacity
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_mounts_proc_timer_list_free
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_mounts_sys_firmware_available
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_mounts_sys_firmware_capacity
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_mounts_sys_firmware_free
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_IpExt_InBcastOctets
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_IpExt_InBcastPkts
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_IpExt_InCEPkts
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_IpExt_InCsumErrors
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_IpExt_InECT0Pkts
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_IpExt_InECT1Pkts
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_IpExt_InMcastOctets
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_IpExt_InMcastPkts
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_netstat_IpExt_InNoECTPkts
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_IpExt_InNoRoutes
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_IpExt_InOctets
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_netstat_IpExt_InTruncatedPkts
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_netstat_IpExt_OutBcastOctets
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_netstat_IpExt_OutBcastPkts
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_netstat_IpExt_OutMcastOctets
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_netstat_IpExt_OutMcastPkts
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_IpExt_OutOctets
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_netstat_IpExt_ReasmOverlaps
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_Ip_DefaultTTL
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_netstat_Ip_ForwDatagrams
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_Ip_Forwarding
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_netstat_Ip_FragCreates
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_netstat_Ip_FragFails
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_Ip_FragOKs
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_Ip_InAddrErrors
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_netstat_Ip_InDelivers
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_netstat_Ip_InDiscards
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_Ip_InHdrErrors
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_Ip_InReceives
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_netstat_Ip_InUnknownProtos
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_netstat_Ip_OutDiscards
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_netstat_Ip_OutNoRoutes
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_Ip_OutRequests
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_netstat_Ip_ReasmFails
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_Ip_ReasmOKs
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_Ip_ReasmReqds
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_Ip_ReasmTimeout
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_ArpFilter
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_BusyPollRxPackets
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_DelayedACKLocked
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_DelayedACKLost
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_DelayedACKs
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_EmbryonicRsts
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_IPReversePathFilter
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_ListenDrops
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_ListenOverflows
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_LockDroppedIcmps
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_OfoPruned
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_OutOfWindowIcmps
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_PAWSActive
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_PAWSEstab
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_PFMemallocDrop
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_PruneCalled
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_RcvPruned
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_SyncookiesFailed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_SyncookiesRecv
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_SyncookiesSent
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPACKSkippedChallenge
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPACKSkippedFinWait2
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPACKSkippedPAWS
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPACKSkippedSeq
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPACKSkippedSynRecv
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPACKSkippedTimeWait
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPAbortFailed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPAbortOnClose
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPAbortOnData
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPAbortOnLinger
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPAbortOnMemory
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPAbortOnTimeout
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPAckCompressed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPAutoCorking
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPBacklogCoalesce
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPBacklogDrop
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPChallengeACK
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPDSACKIgnoredDubious
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPDSACKIgnoredNoUndo
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPDSACKIgnoredOld
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPDSACKOfoRecv
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPDSACKOfoSent
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPDSACKOldSent
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPDSACKRecv
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPDSACKRecvSegs
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPDSACKUndo
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPDeferAcceptDrop
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPDelivered
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPDeliveredCE
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPFastOpenActive
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPFastOpenActiveFail
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPFastOpenBlackhole
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPFastOpenCookieReqd
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPFastOpenListenOverflow
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPFastOpenPassive
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPFastOpenPassiveAltKey
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPFastOpenPassiveFail
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPFastRetrans
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPFromZeroWindowAdv
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPFullUndo
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPHPAcks
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPHPHits
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPHystartDelayCwnd
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPHystartDelayDetect
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPHystartTrainCwnd
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPHystartTrainDetect
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPKeepAlive
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPLossFailures
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPLossProbeRecovery
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPLossProbes
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPLossUndo
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPLostRetransmit
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPMD5Failure
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPMD5NotFound
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPMD5Unexpected
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPMTUPFail
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPMTUPSuccess
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPMemoryPressures
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPMemoryPressuresChrono
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPMinTTLDrop
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPOFODrop
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPOFOMerge
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPOFOQueue
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPOrigDataSent
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPPartialUndo
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPPureAcks
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPRcvCoalesce
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPRcvCollapsed
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPRcvQDrop
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPRenoFailures
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPRenoRecovery
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPRenoRecoveryFail
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPRenoReorder
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPReqQFullDoCookies
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPReqQFullDrop
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPRetransFail
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPSACKDiscard
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPSACKReneging
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPSACKReorder
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPSYNChallenge
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPSackFailures
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPSackMerged
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPSackRecovery
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPSackRecoveryFail
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPSackShiftFallback
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPSackShifted
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPSlowStartRetrans
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPSpuriousRTOs
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPSpuriousRtxHostQueues
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPSynRetrans
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPTSReorder
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPTimeWaitOverflow
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPTimeouts
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPToZeroWindowAdv
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPWantZeroWindowAdv
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPWinProbe
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPWqueueTooBig
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TCPZeroWindowDrop
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TW
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TWKilled
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TWRecycled
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TcpDuplicateDataRehash
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_netstat_TcpExt_TcpTimeoutRehash
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_Tcp_ActiveOpens
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_Tcp_AttemptFails
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_Tcp_CurrEstab
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_netstat_Tcp_EstabResets
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_netstat_Tcp_InCsumErrors
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_netstat_Tcp_InErrs
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_Tcp_InSegs
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_Tcp_OutRsts
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_netstat_Tcp_OutSegs
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_Tcp_PassiveOpens
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_Tcp_RetransSegs
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_Tcp_RtoAlgorithm
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_Tcp_RtoMax
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_netstat_Tcp_RtoMin
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_start
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_sys_vmstat_balloon_deflate
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_sys_vmstat_balloon_inflate
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_vmstat_nr_mlock
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_vmstat_pgfault
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_vmstat_pgmajfault
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_sys_vmstat_pswpin
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_sys_vmstat_pswpout
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_term
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_writeMajorityCount
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+    internalAttributes:
+      - name: newrelic.integrationName
+        type: string
+      - name: newrelic.integrationVersion
+        type: string
+      - name: newrelic.source
+        type: string
+      - name: newrelic.agentVersion
+        type: string
+    ignoredAttributes:
+      - agentName
+      - coreCount
+      - processorCount
+      - systemMemoryBytes
+    tags: []
+  - entityType: MONGODB_COLLECTION
+    metrics:
+      - name: mongodb_collstats_latencyStats_commands_latency
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+      - name: mongodb_collstats_latencyStats_commands_ops
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_collstats_latencyStats_reads_latency
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+      - name: mongodb_collstats_latencyStats_reads_ops
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+          - name: database
+            type: string
+      - name: mongodb_collstats_latencyStats_transactions_latency
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_collstats_latencyStats_transactions_ops
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_collstats_latencyStats_writes_latency
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_collstats_latencyStats_writes_ops
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_collstats_localTime
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_collstats_storageStats_avgObjSize
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_collstats_storageStats_capped
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_collstats_storageStats_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_collstats_storageStats_indexSizes_callingCode_1
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_collstats_storageStats_indexSizes_capital_text
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_collstats_storageStats_indexSizes_id
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_collstats_storageStats_nindexes
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_collstats_storageStats_scaleFactor
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+      - name: mongodb_collstats_storageStats_size
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_collstats_storageStats_storageSize
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_collstats_storageStats_totalIndexSize
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_indexstats_accesses_ops
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: key_name
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+          - name: database
+            type: string
+      - name: mongodb_top_commands_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_top_commands_time
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_top_getmore_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_top_getmore_time
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_top_insert_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+          - name: database
+            type: string
+      - name: mongodb_top_insert_time
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_top_queries_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_top_queries_time
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_top_readLock_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_top_readLock_time
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+      - name: mongodb_top_remove_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_top_remove_time
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_top_total_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_top_total_time
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_top_update_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+          - name: database
+            type: string
+      - name: mongodb_top_update_time
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+      - name: mongodb_top_writeLock_count
+        type: count
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+      - name: mongodb_top_writeLock_time
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: collection
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+    internalAttributes:
+      - name: newrelic.integrationName
+        type: string
+      - name: newrelic.integrationVersion
+        type: string
+      - name: newrelic.source
+        type: string
+      - name: newrelic.agentVersion
+        type: string
+    ignoredAttributes:
+      - agentName
+      - coreCount
+      - processorCount
+      - systemMemoryBytes
+    tags: []
+  - entityType: MONGODB_DATABASE
+    metrics:
+      - name: mongodb_dbstats_avgObjSize
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_dbstats_clusterTime_signature_keyId
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_dbstats_collections
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_dbstats_configServerState_opTime_t
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+      - name: mongodb_dbstats_dataSize
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: database
+            type: string
+      - name: mongodb_dbstats_fsTotalSize
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_dbstats_fsUsedSize
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: database
+            type: string
+      - name: mongodb_dbstats_indexSize
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_dbstats_indexes
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_dbstats_numExtents
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: database
+            type: string
+      - name: mongodb_dbstats_objects
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+      - name: mongodb_dbstats_ok
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: database
+            type: string
+      - name: mongodb_dbstats_scaleFactor
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_role
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+      - name: mongodb_dbstats_storageSize
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: database
+            type: string
+      - name: mongodb_dbstats_views
+        type: gauge
+        defaultResolution: 15
+        unit: count
+        dimensions:
+          - name: cl_id
+            type: string
+          - name: cl_role
+            type: string
+          - name: database
+            type: string
+          - name: rs_nm
+            type: string
+          - name: rs_state
+            type: string
+    internalAttributes:
+      - name: newrelic.integrationName
+        type: string
+      - name: newrelic.integrationVersion
+        type: string
+      - name: newrelic.source
+        type: string
+      - name: newrelic.agentVersion
+        type: string
+    ignoredAttributes:
+      - agentName
+      - coreCount
+      - processorCount
+      - systemMemoryBytes
+    tags: []


### PR DESCRIPTION
This PR adds the spec file for the e2e.

The only consideration here it's that there're a ton of metrics that are reported as `untyped` type. By default they are set to `gauge` by the tool. I tried to check them but there are >1k metrics fitting this case. So, it's hard for me to say that all of them are properly set 😅 

All the exporter metrics are listed in this internal sheet: https://docs.google.com/spreadsheets/d/1aYdE58VQryLJ4TGFGvOW9ZlPvB2oWwrFNY5ECANeILU/edit?pli=1#gid=1357724511