### PR TITLE
remove default GOARCH

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,6 +25,6 @@ jobs:
         uses: newrelic/newrelic-integration-e2e-action@v1
         with:
           spec_path: exporters/${{ github.event.inputs.exporter }}/e2e/e2e_spec.yml
-          account_id: ${{ secrets.ACCOUNT_ID }}
-          api_key: ${{ secrets.API_KEY }}
-          license_key: ${{ secrets.LICENSE_KEY }}
+          account_id: ${{ secrets.COREINT_E2E_ACCOUNT_ID }}
+          api_key: ${{ secrets.COREINT_E2E_API_KEY }}
+          license_key: ${{ secrets.COREINT_E2E_LICENSE_KEY }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -60,6 +60,6 @@ jobs:
         uses: newrelic/newrelic-integration-e2e-action@v1
         with:
           spec_path: exporters/${{ steps.check.outputs.NAME }}/e2e/e2e_spec.yml
-          account_id: ${{ secrets.ACCOUNT_ID }}
-          api_key: ${{ secrets.API_KEY }}
-          license_key: ${{ secrets.LICENSE_KEY }}
+          account_id: ${{ secrets.COREINT_E2E_ACCOUNT_ID }}
+          api_key: ${{ secrets.COREINT_E2E_API_KEY }}
+          license_key: ${{ secrets.COREINT_E2E_LICENSE_KEY }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -48,9 +48,9 @@ jobs:
         uses: newrelic/newrelic-integration-e2e-action@v1
         with:
           spec_path: exporters/${{ steps.check.outputs.NAME }}/e2e/e2e_spec.yml
-          account_id: ${{ secrets.ACCOUNT_ID }}
-          api_key: ${{ secrets.API_KEY }}
-          license_key: ${{ secrets.LICENSE_KEY }}
+          account_id: ${{ secrets.COREINT_E2E_ACCOUNT_ID }}
+          api_key: ${{ secrets.COREINT_E2E_API_KEY }}
+          license_key: ${{ secrets.COREINT_E2E_LICENSE_KEY }}
       - name: Create Release for the exporter modified
         id: create_release
         if: ${{ steps.check.outputs.CREATE_RELEASE == 'true'}}

--- a/README.md
+++ b/README.md
@@ -47,7 +47,11 @@ sudo zypper install <exporter package name>
 
 ## Local Build and Test
 
-There are Make targets that helps you build and run e2e test locally:
+Make sure you have installed:
+- [Go](https://go.dev/doc/install)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+
+There are Make targets that help you build and run e2e tests locally:
 
 * Compile an integration:
 ```bash
@@ -57,15 +61,11 @@ make build-<exporter_name>
 
 * Run End to End test:
 ```bash
-make fetch-resources-<exporter_name>
-make build-<exporter_name>
 make test-e2e-<exporter_name> \
   ACCOUNT_ID=<NEWRELIC_ACCOUNT_ID> \
   API_KEY=<NEWRELIC_API_KEY> \
   LICENSE_KEY=<NEWRELIC_LICENSE_KEY>
 ```
-
-Go `1.17+` is needed in order to run the e2e test without installing the `newrelic-integration-e2e`.
 
 ### nri-config-generator
 `nri-config-generator` folder contains all the code needed to build a binary capable to get as input the classical 

--- a/exporters/ibmmq/e2e/agent_dir/newrelic-infra-agent/Dockerfile
+++ b/exporters/ibmmq/e2e/agent_dir/newrelic-infra-agent/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir -p /opt/mqm \
 # Location of the downloadable MQ client package \
 ENV RDURL="https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist" \
     RDTAR="IBM-MQC-Redist-LinuxX64.tar.gz" \
-    VRMF=9.2.4.0
+    VRMF=9.2.5.0
 
 # Install the MQ client from the Redistributable package. This also contains the
 # header files we need to compile against. Setup the subset of the package

--- a/exporters/powerdns/build.sh
+++ b/exporters/powerdns/build.sh
@@ -14,10 +14,7 @@ else
     git checkout ${EXPORTER_TAG} -d
 fi
 
-goos=$2
-goarch=$3
-
-GOOS="$goos" GOARCH="$goarch" make build
+make build
 
 mkdir -p ${powerdns_bin_dir}
 

--- a/scripts/build_generator.sh
+++ b/scripts/build_generator.sh
@@ -22,8 +22,6 @@ else
 fi
 
 cd nri-config-generator && \
-  GOOS=linux \
-  GOARCH=amd64 \
   BIN_PATH=${binary_dir}/nri-${integration} \
   make compile 
 


### PR DESCRIPTION
- Removes the defaults GOOS and GOARCH for generator breaking the local execution
- Removes the defaults GOOS and GOARCH for the build target braking the GHA execution
- Fixes link to ibmmq required library for e2e
- Replaces local for org secrets