### PR TITLE
NRI-68830: enable config-generator's test-windows job

### DIFF
--- a/.github/workflows/nri-config-generator.yml
+++ b/.github/workflows/nri-config-generator.yml
@@ -11,7 +11,7 @@ name: nri-config-generator pipeline
 on:
   pull_request:
     branches: [ main ]
-    paths: [ nri-config-generator/** ]
+#    paths: [ nri-config-generator/** ]  # always enabled temporally to check test-windows job
 
 jobs:
 
@@ -38,16 +38,16 @@ jobs:
         working-directory: nri-config-generator
         run: make test
 
-#  test-windows:
-#    name: Run unit tests on Windows
-#    runs-on: windows-2019
-#    steps:
-#      - uses: actions/checkout@v3
-#      - uses: actions/setup-go@v3
-#        with:
-#          go-version-file: 'nri-config-generator/go.mod'
-#      - name: Tests
-#        shell: pwsh
-#        working-directory: nri-config-generator
-#        run: |
-#          go test ./...
+  test-windows:
+    name: Run unit tests on Windows
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: 'nri-config-generator/go.mod'
+      - name: Tests
+        shell: pwsh
+        working-directory: nri-config-generator
+        run: |
+          go test ./...

--- a/.github/workflows/nri-config-generator.yml
+++ b/.github/workflows/nri-config-generator.yml
@@ -11,7 +11,7 @@ name: nri-config-generator pipeline
 on:
   pull_request:
     branches: [ main ]
-#    paths: [ nri-config-generator/** ]  # always enabled temporally to check test-windows job
+    paths: [ nri-config-generator/** ]
 
 jobs:
 


### PR DESCRIPTION
This PR enables config-generator's tests on windows again.

It seems to have something to do with the GH windows-2019 image version but I didn't find any obvious change between (2) and (3) versions. Some context and logs fragments are included bellow.

### (1) Pipeline wasn't failing but integration tests weren't found

Test were enabled before but the config-generator's integration tests weren't executed. Example [here](https://github.com/newrelic/newrelic-prometheus-exporters-packages/actions/runs/3287996676/jobs/5417805978):

```
2022-10-20T08:25:55.0675011Z Requested labels: windows-2019
2022-10-20T08:25:55.0675061Z Job defined at: newrelic/newrelic-prometheus-exporters-packages/.github/workflows/nri-config-generator.yml@refs/pull/119/merge
2022-10-20T08:25:55.0675082Z Waiting for a runner to pick up this job...
2022-10-20T08:26:09.3641510Z Job is waiting for a hosted runner to come online.
2022-10-20T08:26:20.1074990Z Job is about to start running on the hosted runner: GitHub Actions 68 (hosted)
2022-10-20T08:26:24.5050587Z Current runner version: '2.298.2'
2022-10-20T08:26:24.5083711Z ##[group]Operating System
2022-10-20T08:26:24.5084251Z Microsoft Windows Server 2019
2022-10-20T08:26:24.5084682Z 10.0.17763
2022-10-20T08:26:24.5085006Z Datacenter
2022-10-20T08:26:24.5085343Z ##[endgroup]
2022-10-20T08:26:24.5085719Z ##[group]Runner Image
2022-10-20T08:26:24.5086072Z Image: windows-2019
2022-10-20T08:26:24.5086431Z Version: 20221012.3
2022-10-20T08:26:24.5087006Z Included Software: https://github.com/actions/runner-images/blob/win19/20221012.3/images/win/Windows2019-Readme.md
2022-10-20T08:26:24.5087767Z Image Release: https://github.com/actions/runner-images/releases/tag/win19%2F20221012.3
2022-10-20T08:26:24.5088283Z ##[endgroup]

(...)

2022-10-20T08:27:05.0669911Z --- Running tests

(...)

2022-10-20T08:28:20.6039607Z ok  	github.com/newrelic/nri-config-generator	0.038s
2022-10-20T08:28:20.6056420Z ?   	github.com/newrelic/nri-config-generator/integration-tests	[no test files]
2022-10-20T08:28:21.2773549Z ok  	github.com/newrelic/nri-config-generator/internal/config	0.044s
2022-10-20T08:28:21.3489205Z ok  	github.com/newrelic/nri-config-generator/internal/generator	0.042s
2022-10-20T08:28:32.6822842Z ok  	github.com/newrelic/nri-config-generator/internal/httport	10.826s
```

### (2) Pipeline started to fail (integration tests being executed)

We ended up disabling config-generator's tests for Windows. Example [here](https://github.com/newrelic/newrelic-prometheus-exporters-packages/actions/runs/3548513379/jobs/5959804110)

```
2022-11-25T13:54:29.6701252Z Requested labels: windows-2019
2022-11-25T13:54:29.6701305Z Job defined at: newrelic/newrelic-prometheus-exporters-packages/.github/workflows/nri-config-generator.yml@refs/pull/136/merge
2022-11-25T13:54:29.6701327Z Waiting for a runner to pick up this job...
2022-11-25T13:54:31.0967690Z Job is waiting for a hosted runner to come online.
2022-11-25T13:54:39.4396852Z Job is about to start running on the hosted runner: GitHub Actions 4 (hosted)
2022-11-25T13:54:43.6475799Z Current runner version: '2.299.1'
2022-11-25T13:54:43.6503863Z ##[group]Operating System
2022-11-25T13:54:43.6504442Z Microsoft Windows Server 2019
2022-11-25T13:54:43.6504702Z 10.0.17763
2022-11-25T13:54:43.6504969Z Datacenter
2022-11-25T13:54:43.6505238Z ##[endgroup]
2022-11-25T13:54:43.6505498Z ##[group]Runner Image
2022-11-25T13:54:43.6505817Z Image: windows-2019
2022-11-25T13:54:43.6506107Z Version: 20221119.1
2022-11-25T13:54:43.6506525Z Included Software: https://github.com/actions/runner-images/blob/win19/20221119.1/images/win/Windows2019-Readme.md
2022-11-25T13:54:43.6507107Z Image Release: https://github.com/actions/runner-images/releases/tag/win19%2F20221119.1
2022-11-25T13:54:43.6507539Z ##[endgroup]

(...)

2022-11-25T13:55:03.0318814Z ##[group]Run go test ./...
2022-11-25T13:55:03.0319302Z [36;1mgo test ./...[0m
2022-11-25T13:55:03.0344693Z shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
2022-11-25T13:55:03.0345087Z ##[endgroup]

(...)

2022-11-25T13:56:04.2802723Z ok  	github.com/newrelic/nri-config-generator	0.035s
2022-11-25T13:56:12.0469976Z --- FAIL: TestGeneratorConfig (3.15s)
2022-11-25T13:56:12.0470578Z     generator_test.go:114: 
2022-11-25T13:56:12.0470935Z     generator_test.go:115: 
2022-11-25T13:56:12.0471970Z         	Error Trace:	D:\a\newrelic-prometheus-exporters-packages\newrelic-prometheus-exporters-packages\nri-config-generator\integration-tests\generator_test.go:115
2022-11-25T13:56:12.0472656Z         	Error:      	Received unexpected error:
2022-11-25T13:56:12.0473068Z         	            	exit status 1
2022-11-25T13:56:12.0473426Z         	Test:       	TestGeneratorConfig
2022-11-25T13:56:12.0473740Z     generator_test.go:116: 
2022-11-25T13:56:12.0474710Z         	Error Trace:	D:\a\newrelic-prometheus-exporters-packages\newrelic-prometheus-exporters-packages\nri-config-generator\integration-tests\generator_test.go:116
2022-11-25T13:56:12.0475569Z         	Error:      	Should NOT be empty, but was []
2022-11-25T13:56:12.0475966Z         	Test:       	TestGeneratorConfig
2022-11-25T13:56:12.0476348Z     generator_test.go:117: 
2022-11-25T13:56:12.0478816Z         	Error Trace:	D:\a\newrelic-prometheus-exporters-packages\newrelic-prometheus-exporters-packages\nri-config-generator\integration-tests\generator_test.go:117
2022-11-25T13:56:12.0479556Z         	Error:      	Input ('') needs to be valid json.
2022-11-25T13:56:12.0480241Z         	            	JSON parsing error: 'unexpected end of JSON input'
2022-11-25T13:56:12.0480628Z         	Test:       	TestGeneratorConfig
2022-11-25T13:56:12.0480893Z [WARN] http: Server closed
2022-11-25T13:56:12.0481232Z --- FAIL: TestGeneratorConfigPortAlreadyInUse (1.60s)
2022-11-25T13:56:12.0481588Z     generator_test.go:135: 
2022-11-25T13:56:12.0482566Z         	Error Trace:	D:\a\newrelic-prometheus-exporters-packages\newrelic-prometheus-exporters-packages\nri-config-generator\integration-tests\generator_test.go:135
2022-11-25T13:56:12.0483225Z         	Error:      	Received unexpected error:
2022-11-25T13:56:12.0483633Z         	            	exit status 1
2022-11-25T13:56:12.0484056Z         	Test:       	TestGeneratorConfigPortAlreadyInUse
2022-11-25T13:56:12.0484410Z     generator_test.go:136: 
2022-11-25T13:56:12.0485393Z         	Error Trace:	D:\a\newrelic-prometheus-exporters-packages\newrelic-prometheus-exporters-packages\nri-config-generator\integration-tests\generator_test.go:136
2022-11-25T13:56:12.0486055Z         	Error:      	Should NOT be empty, but was []
2022-11-25T13:56:12.0486519Z         	Test:       	TestGeneratorConfigPortAlreadyInUse
2022-11-25T13:56:12.0487014Z     generator_test.go:138: 
2022-11-25T13:56:12.0487967Z         	Error Trace:	D:\a\newrelic-prometheus-exporters-packages\newrelic-prometheus-exporters-packages\nri-config-generator\integration-tests\generator_test.go:138
2022-11-25T13:56:12.0488853Z         	Error:      	Expected nil, but got: &json.SyntaxError{msg:"unexpected end of JSON input", Offset:0}
2022-11-25T13:56:12.0489392Z         	Test:       	TestGeneratorConfigPortAlreadyInUse
2022-11-25T13:56:12.0489744Z     generator_test.go:143: 
2022-11-25T13:56:12.0490706Z         	Error Trace:	D:\a\newrelic-prometheus-exporters-packages\newrelic-prometheus-exporters-packages\nri-config-generator\integration-tests\generator_test.go:143
2022-11-25T13:56:12.0491425Z         	Error:      	Input ('') needs to be valid json.
2022-11-25T13:56:12.0492100Z         	            	JSON parsing error: 'unexpected end of JSON input'
2022-11-25T13:56:12.0492586Z         	Test:       	TestGeneratorConfigPortAlreadyInUse
2022-11-25T13:56:12.0492943Z --- FAIL: TestGeneratorConfigWithInterval (2.54s)
2022-11-25T13:56:12.0493299Z     generator_test.go:151: 
2022-11-25T13:56:12.0494268Z         	Error Trace:	D:\a\newrelic-prometheus-exporters-packages\newrelic-prometheus-exporters-packages\nri-config-generator\integration-tests\generator_test.go:151
2022-11-25T13:56:12.0494928Z         	Error:      	Received unexpected error:
2022-11-25T13:56:12.0495322Z         	            	exit status 1
2022-11-25T13:56:12.0495734Z         	Test:       	TestGeneratorConfigWithInterval
2022-11-25T13:56:12.0496077Z     generator_test.go:152: 
2022-11-25T13:56:12.0497040Z         	Error Trace:	D:\a\newrelic-prometheus-exporters-packages\newrelic-prometheus-exporters-packages\nri-config-generator\integration-tests\generator_test.go:152
2022-11-25T13:56:12.0497708Z         	Error:      	Should NOT be empty, but was []
2022-11-25T13:56:12.0498144Z         	Test:       	TestGeneratorConfigWithInterval
2022-11-25T13:56:12.0498487Z     generator_test.go:158: 
2022-11-25T13:56:12.0499433Z         	Error Trace:	D:\a\newrelic-prometheus-exporters-packages\newrelic-prometheus-exporters-packages\nri-config-generator\integration-tests\generator_test.go:158
2022-11-25T13:56:12.0500113Z         	Error:      	Input ('') needs to be valid json.
2022-11-25T13:56:12.0500789Z         	            	JSON parsing error: 'unexpected end of JSON input'
2022-11-25T13:56:12.0501235Z         	Test:       	TestGeneratorConfigWithInterval
2022-11-25T13:56:12.0501573Z --- FAIL: TestGeneratorVerboseMode (2.45s)
2022-11-25T13:56:12.0502299Z     generator_test.go:166: 
2022-11-25T13:56:12.0503272Z         	Error Trace:	D:\a\newrelic-prometheus-exporters-packages\newrelic-prometheus-exporters-packages\nri-config-generator\integration-tests\generator_test.go:166
2022-11-25T13:56:12.0503936Z         	Error:      	Received unexpected error:
2022-11-25T13:56:12.0504346Z         	            	exit status 1
2022-11-25T13:56:12.0504725Z         	Test:       	TestGeneratorVerboseMode
2022-11-25T13:56:12.0505028Z     generator_test.go:167: 
2022-11-25T13:56:12.0506006Z         	Error Trace:	D:\a\newrelic-prometheus-exporters-packages\newrelic-prometheus-exporters-packages\nri-config-generator\integration-tests\generator_test.go:167
2022-11-25T13:56:12.0506687Z         	Error:      	Should NOT be empty, but was []
2022-11-25T13:56:12.0507084Z         	Test:       	TestGeneratorVerboseMode
2022-11-25T13:56:12.0507404Z     generator_test.go:173: 
2022-11-25T13:56:12.0508384Z         	Error Trace:	D:\a\newrelic-prometheus-exporters-packages\newrelic-prometheus-exporters-packages\nri-config-generator\integration-tests\generator_test.go:173
2022-11-25T13:56:12.0509063Z         	Error:      	Input ('') needs to be valid json.
2022-11-25T13:56:12.0509709Z         	            	JSON parsing error: 'unexpected end of JSON input'
2022-11-25T13:56:12.0510140Z         	Test:       	TestGeneratorVerboseMode
2022-11-25T13:56:12.0510373Z FAIL
2022-11-25T13:56:12.0510759Z FAIL	github.com/newrelic/nri-config-generator/integration-tests	9.814s
2022-11-25T13:56:12.0511179Z ok  	github.com/newrelic/nri-config-generator/internal/config	0.057s
2022-11-25T13:56:12.0511590Z ok  	github.com/newrelic/nri-config-generator/internal/generator	0.042s
2022-11-25T13:56:14.6764031Z ok  	github.com/newrelic/nri-config-generator/internal/httport	10.727s
2022-11-25T13:56:14.6764708Z FAIL
2022-11-25T13:56:14.8193554Z ##[error]Process completed with exit code 1.
```

### (3) Now config-generator's tests are enabled and there are no errors

Example [here](https://github.com/newrelic/newrelic-prometheus-exporters-packages/actions/runs/3693414986/jobs/6253375088)

```
2022-12-14T09:20:09.6378857Z Requested labels: windows-2019
2022-12-14T09:20:09.6378896Z Job defined at: newrelic/newrelic-prometheus-exporters-packages/.github/workflows/nri-config-generator.yml@refs/pull/138/merge
2022-12-14T09:20:09.6378921Z Waiting for a runner to pick up this job...
2022-12-14T09:20:11.3529315Z Job is waiting for a hosted runner to come online.
2022-12-14T09:20:17.7798821Z Job is about to start running on the hosted runner: GitHub Actions 11 (hosted)
2022-12-14T09:20:22.4155340Z Current runner version: '2.299.1'
2022-12-14T09:20:22.4211918Z ##[group]Operating System
2022-12-14T09:20:22.4212838Z Microsoft Windows Server 2019
2022-12-14T09:20:22.4213557Z 10.0.17763
2022-12-14T09:20:22.4214103Z Datacenter
2022-12-14T09:20:22.4214605Z ##[endgroup]
2022-12-14T09:20:22.4217798Z ##[group]Runner Image
2022-12-14T09:20:22.4218637Z Image: windows-2019
2022-12-14T09:20:22.4219256Z Version: 20221204.2
2022-12-14T09:20:22.4220244Z Included Software: https://github.com/actions/runner-images/blob/win19/20221204.2/images/win/Windows2019-Readme.md
2022-12-14T09:20:22.4221504Z Image Release: https://github.com/actions/runner-images/releases/tag/win19%2F20221204.2
2022-12-14T09:20:22.4222356Z ##[endgroup]

(...)

2022-12-14T09:20:40.3678301Z ##[group]Run go test ./...
2022-12-14T09:20:40.3678763Z [36;1mgo test ./...[0m
2022-12-14T09:20:40.4715372Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
2022-12-14T09:20:40.4715898Z ##[endgroup]

(...)

2022-12-14T09:21:28.0149918Z ok  	github.com/newrelic/nri-config-generator	0.037s
2022-12-14T09:21:37.9029933Z ok  	github.com/newrelic/nri-config-generator/integration-tests	9.342s
2022-12-14T09:21:37.9030519Z ok  	github.com/newrelic/nri-config-generator/internal/config	0.044s
2022-12-14T09:21:37.9031024Z ok  	github.com/newrelic/nri-config-generator/internal/generator	0.144s
2022-12-14T09:21:41.4622554Z ok  	github.com/newrelic/nri-config-generator/internal/httport	11.041s

```