### PR TITLE
Use the new rotated secrets

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -6,8 +6,8 @@ on:
       - main
 
 env:
-  PFX_CERTIFICATE_BASE64: ${{ secrets.PFX_CERTIFICATE_BASE64 }} # base64 encoded
-  PFX_PASSPHRASE:  ${{ secrets.PFX_PASSPHRASE }}
+  OHAI_PFX_CERTIFICATE_BASE64: ${{ secrets.OHAI_PFX_CERTIFICATE_BASE64 }} # base64 encoded
+  OHAI_PFX_PASSPHRASE:  ${{ secrets.OHAI_PFX_PASSPHRASE }}
   GO_VERSION: '1.18'
 
 ###
@@ -203,7 +203,7 @@ jobs:
           go-version: ${{env.GO_VERSION}}
       - name: Get PFX certificate from GH secrets
         shell: bash
-        run: printf "%s" "$PFX_CERTIFICATE_BASE64" | base64 -d - > mycert.pfx
+        run: printf "%s" "$OHAI_PFX_CERTIFICATE_BASE64" | base64 -d - > mycert.pfx
       - name: Load Variables
         id: vars
         shell: bash
@@ -227,7 +227,7 @@ jobs:
       - name : Create MSI installer
         shell: pwsh
         run: |
-          .\scripts\win_msi_build.ps1 -arch ${{ matrix.goarch }} -exporterName ${{ steps.vars.outputs.NAME }} -version ${{ steps.vars.outputs.VERSION }} -exporterGUID ${{ steps.vars.outputs.EXPORTER_GUID }} -upgradeGUID ${{ steps.vars.outputs.UPGRADE_GUID }} -licenseGUID ${{ steps.vars.outputs.LICENSE_GUID }} -configGUID ${{ steps.vars.outputs.CONFIG_GUID }} -pfx_passphrase "$env:PFX_PASSPHRASE"
+          .\scripts\win_msi_build.ps1 -arch ${{ matrix.goarch }} -exporterName ${{ steps.vars.outputs.NAME }} -version ${{ steps.vars.outputs.VERSION }} -exporterGUID ${{ steps.vars.outputs.EXPORTER_GUID }} -upgradeGUID ${{ steps.vars.outputs.UPGRADE_GUID }} -licenseGUID ${{ steps.vars.outputs.LICENSE_GUID }} -configGUID ${{ steps.vars.outputs.CONFIG_GUID }} -pfx_passphrase "$env:OHAI_PFX_PASSPHRASE"
       - name: Test win packages installation
         uses: newrelic/integrations-pkg-test-action/windows@v1
         with:


### PR DESCRIPTION
We were pointing to the old expired secrets. 

Notice I updated the old ones to check that the error signing the msi package was because of that. However, these secrets aren' going to be rotated anymore so we need to use the new ones.