### PR TITLE
NR-75936: powerdns arm release

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feat/powerdns-arm-release
 
 permissions:
   contents: write
@@ -217,49 +218,49 @@ jobs:
         with:
           name: publish-schema
           path: .
-      - name: Create Release for the exporter modified
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ needs.check_exporter_preconditions.outputs.RELEASE_TAG }}
-          name: ${{ needs.check_exporter_preconditions.outputs.INTEGRATION_NAME }} ${{ needs.check_exporter_preconditions.outputs.INTEGRATION_VERSION }}
-          prerelease: true
-          body: |
-            Changes in ${{ needs.check_exporter_preconditions.outputs.PACKAGE_NAME }} version ${{ needs.check_exporter_preconditions.outputs.VERSION }}
-              - Exporter repository URL: ${{ needs.check_exporter_preconditions.outputs.EXPORTER_REPO_URL }}
-              - Commit or Tag of the exporter packaged: ${{ needs.check_exporter_preconditions.outputs.EXPORTER_HEAD }}
-              - CHANGELOG: ${{ needs.check_exporter_preconditions.outputs.EXPORTER_CHANGELOG }}
-          files: |
-            packages/*
-      - name: Publish to S3 action (staging)
-        uses: newrelic/infrastructure-publish-action@v1
-        env:
-          AWS_S3_BUCKET_NAME: "nr-downloads-ohai-staging"
-          AWS_S3_LOCK_BUCKET_NAME: "onhost-ci-lock-staging"
-          ACCESS_POINT_HOST: "staging"
-        with:
-          disable_lock: false
-          run_id: ${{ github.run_id }}
-          tag: ${{ needs.check_exporter_preconditions.outputs.RELEASE_TAG }}
-          app_version: ${{ needs.check_exporter_preconditions.outputs.INTEGRATION_VERSION }}
-          app_name: nri-${{ needs.check_exporter_preconditions.outputs.INTEGRATION_NAME }}
-          repo_name: ${{ github.event.repository.full_name }}
-          schema: "custom-local"
-          schema_path: ./s3-publish-schema-tmp.yml
-          access_point_host: ${{ env.ACCESS_POINT_HOST }}
-          aws_region: "us-east-1"
-          aws_role_arn: ${{ secrets.OHAI_AWS_ROLE_ARN_STAGING }}
-          aws_role_session_name: ${{ secrets.OHAI_AWS_ROLE_SESSION_NAME_STAGING }}
-          aws_access_key_id: ${{ secrets.OHAI_AWS_ACCESS_KEY_ID_STAGING }}
-          aws_secret_access_key: ${{ secrets.OHAI_AWS_SECRET_ACCESS_KEY_STAGING }}
-          aws_s3_bucket_name: ${{ env.AWS_S3_BUCKET_NAME }}
-          aws_s3_lock_bucket_name: ${{ env.AWS_S3_LOCK_BUCKET_NAME }}
-          gpg_passphrase: ${{ secrets.OHAI_GPG_PASSPHRASE }}
-          gpg_private_key_base64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }}
-      - name: Test package installability (staging)
-        uses: newrelic/integrations-pkg-test-action/linux@v1
-        with:
-          tag: ${{ needs.check_exporter_preconditions.outputs.INTEGRATION_VERSION }}
-          integration: nri-${{ needs.check_exporter_preconditions.outputs.INTEGRATION_NAME }}
-          packageLocation: repo
-          stagingRepo: true
-          upgrade: false
+      #- name: Create Release for the exporter modified
+      #  uses: softprops/action-gh-release@v1
+      #  with:
+      #    tag_name: ${{ needs.check_exporter_preconditions.outputs.RELEASE_TAG }}
+      #    name: ${{ needs.check_exporter_preconditions.outputs.INTEGRATION_NAME }} ${{ needs.check_exporter_preconditions.outputs.INTEGRATION_VERSION }}
+      #    prerelease: true
+      #    body: |
+      #      Changes in ${{ needs.check_exporter_preconditions.outputs.PACKAGE_NAME }} version ${{ needs.check_exporter_preconditions.outputs.VERSION }}
+      #        - Exporter repository URL: ${{ needs.check_exporter_preconditions.outputs.EXPORTER_REPO_URL }}
+      #        - Commit or Tag of the exporter packaged: ${{ needs.check_exporter_preconditions.outputs.EXPORTER_HEAD }}
+      #        - CHANGELOG: ${{ needs.check_exporter_preconditions.outputs.EXPORTER_CHANGELOG }}
+      #    files: |
+      #      packages/*
+      #- name: Publish to S3 action (staging)
+      #  uses: newrelic/infrastructure-publish-action@v1
+      #  env:
+      #    AWS_S3_BUCKET_NAME: "nr-downloads-ohai-staging"
+      #    AWS_S3_LOCK_BUCKET_NAME: "onhost-ci-lock-staging"
+      #    ACCESS_POINT_HOST: "staging"
+      #  with:
+      #    disable_lock: false
+      #    run_id: ${{ github.run_id }}
+      #    tag: ${{ needs.check_exporter_preconditions.outputs.RELEASE_TAG }}
+      #    app_version: ${{ needs.check_exporter_preconditions.outputs.INTEGRATION_VERSION }}
+      #    app_name: nri-${{ needs.check_exporter_preconditions.outputs.INTEGRATION_NAME }}
+      #    repo_name: ${{ github.event.repository.full_name }}
+      #    schema: "custom-local"
+      #    schema_path: ./s3-publish-schema-tmp.yml
+      #    access_point_host: ${{ env.ACCESS_POINT_HOST }}
+      #    aws_region: "us-east-1"
+      #    aws_role_arn: ${{ secrets.OHAI_AWS_ROLE_ARN_STAGING }}
+      #    aws_role_session_name: ${{ secrets.OHAI_AWS_ROLE_SESSION_NAME_STAGING }}
+      #    aws_access_key_id: ${{ secrets.OHAI_AWS_ACCESS_KEY_ID_STAGING }}
+      #    aws_secret_access_key: ${{ secrets.OHAI_AWS_SECRET_ACCESS_KEY_STAGING }}
+      #    aws_s3_bucket_name: ${{ env.AWS_S3_BUCKET_NAME }}
+      #    aws_s3_lock_bucket_name: ${{ env.AWS_S3_LOCK_BUCKET_NAME }}
+      #    gpg_passphrase: ${{ secrets.OHAI_GPG_PASSPHRASE }}
+      #    gpg_private_key_base64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }}
+      #- name: Test package installability (staging)
+      #  uses: newrelic/integrations-pkg-test-action/linux@v1
+      #  with:
+      #    tag: ${{ needs.check_exporter_preconditions.outputs.INTEGRATION_VERSION }}
+      #    integration: nri-${{ needs.check_exporter_preconditions.outputs.INTEGRATION_NAME }}
+      #    packageLocation: repo
+      #    stagingRepo: true
+      #    upgrade: false

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feat/powerdns-arm-release
 
 permissions:
   contents: write
@@ -221,49 +220,49 @@ jobs:
         with:
           name: publish-schema
           path: .
-      #- name: Create Release for the exporter modified
-      #  uses: softprops/action-gh-release@v1
-      #  with:
-      #    tag_name: ${{ needs.check_exporter_preconditions.outputs.RELEASE_TAG }}
-      #    name: ${{ needs.check_exporter_preconditions.outputs.INTEGRATION_NAME }} ${{ needs.check_exporter_preconditions.outputs.INTEGRATION_VERSION }}
-      #    prerelease: true
-      #    body: |
-      #      Changes in ${{ needs.check_exporter_preconditions.outputs.PACKAGE_NAME }} version ${{ needs.check_exporter_preconditions.outputs.VERSION }}
-      #        - Exporter repository URL: ${{ needs.check_exporter_preconditions.outputs.EXPORTER_REPO_URL }}
-      #        - Commit or Tag of the exporter packaged: ${{ needs.check_exporter_preconditions.outputs.EXPORTER_HEAD }}
-      #        - CHANGELOG: ${{ needs.check_exporter_preconditions.outputs.EXPORTER_CHANGELOG }}
-      #    files: |
-      #      packages/*
-      #- name: Publish to S3 action (staging)
-      #  uses: newrelic/infrastructure-publish-action@v1
-      #  env:
-      #    AWS_S3_BUCKET_NAME: "nr-downloads-ohai-staging"
-      #    AWS_S3_LOCK_BUCKET_NAME: "onhost-ci-lock-staging"
-      #    ACCESS_POINT_HOST: "staging"
-      #  with:
-      #    disable_lock: false
-      #    run_id: ${{ github.run_id }}
-      #    tag: ${{ needs.check_exporter_preconditions.outputs.RELEASE_TAG }}
-      #    app_version: ${{ needs.check_exporter_preconditions.outputs.INTEGRATION_VERSION }}
-      #    app_name: nri-${{ needs.check_exporter_preconditions.outputs.INTEGRATION_NAME }}
-      #    repo_name: ${{ github.event.repository.full_name }}
-      #    schema: "custom-local"
-      #    schema_path: ./s3-publish-schema-tmp.yml
-      #    access_point_host: ${{ env.ACCESS_POINT_HOST }}
-      #    aws_region: "us-east-1"
-      #    aws_role_arn: ${{ secrets.OHAI_AWS_ROLE_ARN_STAGING }}
-      #    aws_role_session_name: ${{ secrets.OHAI_AWS_ROLE_SESSION_NAME_STAGING }}
-      #    aws_access_key_id: ${{ secrets.OHAI_AWS_ACCESS_KEY_ID_STAGING }}
-      #    aws_secret_access_key: ${{ secrets.OHAI_AWS_SECRET_ACCESS_KEY_STAGING }}
-      #    aws_s3_bucket_name: ${{ env.AWS_S3_BUCKET_NAME }}
-      #    aws_s3_lock_bucket_name: ${{ env.AWS_S3_LOCK_BUCKET_NAME }}
-      #    gpg_passphrase: ${{ secrets.OHAI_GPG_PASSPHRASE }}
-      #    gpg_private_key_base64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }}
-      #- name: Test package installability (staging)
-      #  uses: newrelic/integrations-pkg-test-action/linux@v1
-      #  with:
-      #    tag: ${{ needs.check_exporter_preconditions.outputs.INTEGRATION_VERSION }}
-      #    integration: nri-${{ needs.check_exporter_preconditions.outputs.INTEGRATION_NAME }}
-      #    packageLocation: repo
-      #    stagingRepo: true
-      #    upgrade: false
+      - name: Create Release for the exporter modified
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ needs.check_exporter_preconditions.outputs.RELEASE_TAG }}
+          name: ${{ needs.check_exporter_preconditions.outputs.INTEGRATION_NAME }} ${{ needs.check_exporter_preconditions.outputs.INTEGRATION_VERSION }}
+          prerelease: true
+          body: |
+            Changes in ${{ needs.check_exporter_preconditions.outputs.PACKAGE_NAME }} version ${{ needs.check_exporter_preconditions.outputs.VERSION }}
+              - Exporter repository URL: ${{ needs.check_exporter_preconditions.outputs.EXPORTER_REPO_URL }}
+              - Commit or Tag of the exporter packaged: ${{ needs.check_exporter_preconditions.outputs.EXPORTER_HEAD }}
+              - CHANGELOG: ${{ needs.check_exporter_preconditions.outputs.EXPORTER_CHANGELOG }}
+          files: |
+            packages/*
+      - name: Publish to S3 action (staging)
+        uses: newrelic/infrastructure-publish-action@v1
+        env:
+          AWS_S3_BUCKET_NAME: "nr-downloads-ohai-staging"
+          AWS_S3_LOCK_BUCKET_NAME: "onhost-ci-lock-staging"
+          ACCESS_POINT_HOST: "staging"
+        with:
+          disable_lock: false
+          run_id: ${{ github.run_id }}
+          tag: ${{ needs.check_exporter_preconditions.outputs.RELEASE_TAG }}
+          app_version: ${{ needs.check_exporter_preconditions.outputs.INTEGRATION_VERSION }}
+          app_name: nri-${{ needs.check_exporter_preconditions.outputs.INTEGRATION_NAME }}
+          repo_name: ${{ github.event.repository.full_name }}
+          schema: "custom-local"
+          schema_path: ./s3-publish-schema-tmp.yml
+          access_point_host: ${{ env.ACCESS_POINT_HOST }}
+          aws_region: "us-east-1"
+          aws_role_arn: ${{ secrets.OHAI_AWS_ROLE_ARN_STAGING }}
+          aws_role_session_name: ${{ secrets.OHAI_AWS_ROLE_SESSION_NAME_STAGING }}
+          aws_access_key_id: ${{ secrets.OHAI_AWS_ACCESS_KEY_ID_STAGING }}
+          aws_secret_access_key: ${{ secrets.OHAI_AWS_SECRET_ACCESS_KEY_STAGING }}
+          aws_s3_bucket_name: ${{ env.AWS_S3_BUCKET_NAME }}
+          aws_s3_lock_bucket_name: ${{ env.AWS_S3_LOCK_BUCKET_NAME }}
+          gpg_passphrase: ${{ secrets.OHAI_GPG_PASSPHRASE }}
+          gpg_private_key_base64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }}
+      - name: Test package installability (staging)
+        uses: newrelic/integrations-pkg-test-action/linux@v1
+        with:
+          tag: ${{ needs.check_exporter_preconditions.outputs.INTEGRATION_VERSION }}
+          integration: nri-${{ needs.check_exporter_preconditions.outputs.INTEGRATION_NAME }}
+          packageLocation: repo
+          stagingRepo: true
+          upgrade: false

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Install goreleaser
         uses: goreleaser/goreleaser-action@v4
         with:
-          version: v1.13.1
+          version: ${{ env.GORELEASER_VERSION }}
           install-only: true
       - name: Get PFX certificate from GH secrets
         shell: bash

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -200,15 +200,18 @@ jobs:
   create_prerelease_and_upload_packages:
     name: Create pre-release and upload packages to staging repositories
     runs-on: ubuntu-latest
-    if: ${{ needs.check_exporter_preconditions.outputs.CREATE_RELEASE == 'true' }}
+    # Using 'always() && !( failure() )' the job is executed unless any of the needed jobs fails (even if some are skipped)
+    if: ${{ always() && !( failure() ) && needs.check_exporter_preconditions.outputs.CREATE_RELEASE == 'true' }}
     needs: [ check_exporter_preconditions, build_linux_artifacts, build_windows_artifacts, create_publish_schema ]
     steps:
       - name: Downloading Linux artifacts
+        if: ${{ needs.check_exporter_preconditions.outputs.PACKAGE_LINUX == 'true' }}
         uses: actions/download-artifact@v3
         with:
           name: linux-artifacts
           path: packages
       - name: Downloading Windows artifacts
+        if: ${{ needs.check_exporter_preconditions.outputs.PACKAGE_WINDOWS == 'true' }}
         uses: actions/download-artifact@v3
         with:
           name: windows-artifacts

--- a/exporters/powerdns/build-exporter-windows.sh
+++ b/exporters/powerdns/build-exporter-windows.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# This script is not currently used as we are not packaging
+# this integration for Windows. It is kept for testing purposes.
+
 set -euo pipefail
 
 # ###############################################################

--- a/exporters/powerdns/exporter.yml
+++ b/exporters/powerdns/exporter.yml
@@ -18,17 +18,3 @@ package_linux: true
 package_linux_goarchs: amd64,arm64
 # Enable packages for Windows
 package_windows: false
-# Upgrade GUID used in the msi package. Required if package_windows is set to true
-# This GUID should be generated and be unique across all exporters in the repository
-upgrade_guid: e854d6c0-e0ce-4f9a-b405-d855a3864307
-# Integration GUID used in the msi package. Required if package_windows is set to true
-# This GUID should be generated and be unique across all exporters in the repository
-nri_guid: 25b3fb82-58e0-41a2-b0d6-f87b16eaa50c
-# Exporter GUID used in the msi package. Required if package_windows is set to true
-# This GUID should be generated and be unique across all exporters in the repository
-exporter_guid: c5a084d2-941a-49ae-836a-255b018cfb17
-# License GUID used in the msi package. Required if package_windows is set to true
-# This GUID should be generated and be unique across all exporters in the repository
-license_guid: 5d2225c3-6b87-45fb-8756-6bf7c0f164fc
-# This GUID should be generated and be unique across all exporters in the repository
-config_guid: 1ed3fde6-1b0c-485e-85e5-7a88d6001be5

--- a/exporters/powerdns/exporter.yml
+++ b/exporters/powerdns/exporter.yml
@@ -1,7 +1,7 @@
 # name of the exporter, should match with the folder name
 name: powerdns
 # version of the package created
-version: 0.0.8
+version: 0.0.9
 # Relative path to the License path from the repository root
 exporter_license_path: LICENSE
 # URL to the git project hosting the exporter
@@ -14,8 +14,10 @@ exporter_commit: fffbd7c4768681f93988c2c3287b690db20e6ce0
 exporter_changelog: https://github.com/lotusnoir/prometheus-powerdns_exporter/tags
 # Enable packages for Linux
 package_linux: true
+# Set goarch values
+package_linux_goarchs: amd64,arm64
 # Enable packages for Windows
-package_windows: true
+package_windows: false
 # Upgrade GUID used in the msi package. Required if package_windows is set to true
 # This GUID should be generated and be unique across all exporters in the repository
 upgrade_guid: e854d6c0-e0ce-4f9a-b405-d855a3864307

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -21,6 +21,11 @@ echo "Loading Variables of of exporter"
 source "${root_dir}"/scripts/common_functions.sh
 loadVariables "${integration_dir}"/exporter.yml
 
+if [[ "$PACKAGE_LINUX" != "true" ]] && [[ "$PACKAGE_WINDOWS" != "true" ]]; then
+    echo "ERROR: the exporter would not be packaged for any supported OS (at least one of package_linux or package_windows should be set to true)"
+    exit 1
+fi
+
 echo "Building exporter"
 bash ${root_dir}/exporters/${integration}/build-exporter-${goos}.sh ${root_dir}
 


### PR DESCRIPTION
We needed to adapt the pre-release pipeline so it is possible to release exporter which are not packaged for both windows and linux.

In order to test this change, the pre-release workflow was temporally changed to not to publish anything (see: [9071a80](https://github.com/newrelic/newrelic-prometheus-exporters-packages/pull/148/commits/9071a80a2eda0f13bdac88124facef270f977643))

After that, the pre-release pipeline was adapted to create the pre-release even if one of the jobs creating artifacts was skipped.

See: https://github.com/newrelic/newrelic-prometheus-exporters-packages/actions/runs/3847945775

<img width="1390" alt="image" src="https://user-images.githubusercontent.com/442627/210824144-5a180eb3-7db0-48d3-88b1-ede43695f87a.png">

<img width="1389" alt="image" src="https://user-images.githubusercontent.com/442627/210824271-2f507433-94c0-4f72-9379-94349b831cc5.png">

Additionally, a new check has been added to the `build.sh` script. No it fails if neither `package_linux` or `package_windows` are set to true in the exporter yaml file.