### PR TITLE
fix(ci/cd): extra nri prefix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - id: release_details
         run: |
-          regex="(.*)-([0-9]+\.[0-9]+\.[0-9]+)"
+          regex="nri-(.*)-([0-9]+\.[0-9]+\.[0-9]+)"
 
           if [[ $TAG =~ $regex ]]; then
               echo "INTEGRATION_NAME=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
@@ -40,7 +40,7 @@ jobs:
           run_id: ${{ github.run_id }}
           tag: ${{ env.TAG }}
           app_version: ${{ steps.release_details.outputs.INTEGRATION_VERSION }}
-          app_name: ${{ steps.release_details.outputs.INTEGRATION_NAME }}
+          app_name: nri-${{ steps.release_details.outputs.INTEGRATION_NAME }}
           repo_name: ${{ github.event.repository.full_name }}
           schema: "custom-local"
           schema_path: ./scripts/pkg/s3-publish-schema-tmp.yml
@@ -58,6 +58,6 @@ jobs:
         uses: newrelic/integrations-pkg-test-action/linux@v1
         with:
           tag: ${{ steps.release_details.outputs.INTEGRATION_VERSION }}
-          integration: '${{ steps.release_details.outputs.INTEGRATION_NAME }}'
+          integration: nri-${{ steps.release_details.outputs.INTEGRATION_NAME }}
           packageLocation: repo
           upgrade: false

--- a/exporters/ibmmq/exporter.yml
+++ b/exporters/ibmmq/exporter.yml
@@ -1,7 +1,7 @@
 # name of the exporter, should match with the folder name
 name: ibmmq
 # version of the package created
-version: 0.4.0
+version: 0.4.1
 # Relative path to the License path from the repository root
 exporter_license_path: LICENSE
 # URL to the git project hosting the exporter


### PR DESCRIPTION
I am following the same approach of prerelease pipeline: `INTEGRATION_NAME` has no "nri" in the name


```
pgallina@ibmmq-pg:~$ TAG=nri-mongodb-0.1.1
pgallina@ibmmq-pg:~$ regex="nri-(.*)-([0-9]+\.[0-9]+\.[0-9]+)"
pgallina@ibmmq-pg:~$                                          
          if [[ $TAG =~ $regex ]]; then
              echo "INTEGRATION_NAME=${BASH_REMATCH[1]}"                  
              echo "INTEGRATION_VERSION=${BASH_REMATCH[2]}"                  
          else
              exit 1
          fi
          
          
          
INTEGRATION_NAME=mongodb
INTEGRATION_VERSION=0.1.1
```

The extra "nri-" was making the pipeline to fail whenever it was trying to create the publish schema