### PR TITLE
Remove e2e retries that are now default (NEWRELIC-6322)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,5 +24,3 @@ jobs:
           account_id: ${{ secrets.COREINT_E2E_ACCOUNT_ID }}
           api_key: ${{ secrets.COREINT_E2E_API_KEY }}
           license_key: ${{ secrets.COREINT_E2E_LICENSE_KEY }}
-          retry_seconds: 60
-          retry_attempts: 15

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -60,5 +60,3 @@ jobs:
           account_id: ${{ secrets.COREINT_E2E_ACCOUNT_ID }}
           api_key: ${{ secrets.COREINT_E2E_API_KEY }}
           license_key: ${{ secrets.COREINT_E2E_LICENSE_KEY }}
-          retry_seconds: 60
-          retry_attempts: 15

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -54,8 +54,6 @@ jobs:
           account_id: ${{ secrets.COREINT_E2E_ACCOUNT_ID }}
           api_key: ${{ secrets.COREINT_E2E_API_KEY }}
           license_key: ${{ secrets.COREINT_E2E_LICENSE_KEY }}
-          retry_seconds: 60
-          retry_attempts: 15
     outputs:
       CREATE_RELEASE: ${{ steps.check.outputs.CREATE_RELEASE }}
       EXPORTER_PATH: ${{ steps.check.outputs.EXPORTER_PATH }}


### PR DESCRIPTION
We merged the Staging feature to the E2E action and fixed the tests in the PR newrelic/newrelic-integration-e2e-action#25.

In the process to fix tests, we also changed the defaults to the new need from the infra-platform so these lines are not needed anymore.