### PR TITLE
NR-90576: mongodb3 exporter port

### DIFF
--- a/exporters/mongodb3/e2e/e2e_spec.yml
+++ b/exporters/mongodb3/e2e/e2e_spec.yml
@@ -20,7 +20,6 @@ scenarios:
           replicaset_stats: true
           top_stats: true
           diagnostic_stats: true
-          exporter_port: 9128
     tests:
       nrqls:
         - query: "SELECT average(mongodb_dbstats_ok) FROM Metric"

--- a/exporters/mongodb3/exporter.yml
+++ b/exporters/mongodb3/exporter.yml
@@ -1,7 +1,7 @@
 # name of the exporter, should match with the folder name
 name: mongodb3
 # version of the package created
-version: 0.0.2
+version: 0.0.3
 # Relative path to the License path from the repository root
 exporter_license_path: LICENSE
 # URL to the git project hosting the exporter

--- a/exporters/mongodb3/mongodb3.json.tmpl
+++ b/exporters/mongodb3/mongodb3.json.tmpl
@@ -51,9 +51,7 @@
 
         "--collector.collstats-limit=0",
 
-        {{ if .config.exporter_port}}
         "--web.listen-address",
-        ":{{.config.exporter_port}}",
-        {{end}}
+        ":{{.exporter_port}}",
     ],
 }

--- a/exporters/mongodb3/mongodb3.json.tmpl
+++ b/exporters/mongodb3/mongodb3.json.tmpl
@@ -51,6 +51,7 @@
 
         "--collector.collstats-limit=0",
 
+        {{/* .exporter_port is filled by the config generator, it uses .config.exporter_port or a random available port if it is not defined  */}}
         "--web.listen-address",
         ":{{.exporter_port}}",
     ],


### PR DESCRIPTION
Support using a random available port in mongodb3 integration when `exporter_port` field is not set.