### PR TITLE
NEWRELIC-4959: feat support scrape timeout

### DIFF
--- a/exporters/powerdns/exporter.yml
+++ b/exporters/powerdns/exporter.yml
@@ -1,7 +1,7 @@
 # name of the exporter, should match with the folder name
 name: powerdns
 # version of the package created
-version: 0.0.9
+version: 0.0.10
 # Relative path to the License path from the repository root
 exporter_license_path: LICENSE
 # URL to the git project hosting the exporter

--- a/exporters/powerdns/powerdns-config.yml.sample
+++ b/exporters/powerdns/powerdns-config.yml.sample
@@ -7,6 +7,9 @@ integrations:
         # Port to expose scrape endpoint on, If this is not provided a random port will be used to launch the exporter
         exporter_port: 9120
 
+        # How long until a scrape request times-out (defaults to 5s)
+        # scrape_timeout: 5s
+
         # API key used to connect to the PowerDNS server
         # api_key: ****-***-*****
 
@@ -16,5 +19,3 @@ integrations:
         #     - prefixes:
         #       - "go_"
         #       - "process_"
-
-

--- a/nri-config-generator/integration-tests/generator_test.go
+++ b/nri-config-generator/integration-tests/generator_test.go
@@ -39,6 +39,7 @@ const configPDNSTemplate = `
         "config": {
           "standalone": false,
          {{ or .pomiVerbose "" }}
+         {{ or .pomiScrapeTimeout "" }}
           "integration_metadata":{
             "name": "nri-powerdns",
             "version": "test-tag"
@@ -167,6 +168,19 @@ func TestGeneratorVerboseMode(t *testing.T) {
 	vars := map[string]string{
 		"exporterPort": exporterPort,
 		"pomiVerbose":  "\"verbose\":\"1\",",
+	}
+	expectedResponse := executeTemplate(t, pdnsTemplate, vars)
+	assert.JSONEq(t, expectedResponse, string(stdout))
+}
+
+func TestGeneratorScrapeTimeout(t *testing.T) {
+	envVars := getConfigGeneratorEnvVars("config_with_scrape_timeout.yml")
+	stdout, err := callGeneratorConfig(defaultArgs, envVars)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, stdout)
+	vars := map[string]string{
+		"exporterPort":      exporterPort,
+		"pomiScrapeTimeout": `"scrape_timeout": "10s",`,
 	}
 	expectedResponse := executeTemplate(t, pdnsTemplate, vars)
 	assert.JSONEq(t, expectedResponse, string(stdout))

--- a/nri-config-generator/integration-tests/testdata/config_with_port.yml
+++ b/nri-config-generator/integration-tests/testdata/config_with_port.yml
@@ -1,7 +1,0 @@
-parent:
-  child:
-    - element1: a
-    - element2: b
-ravendb_url: "http://live-test.ravendb.net"
-other: 123
-exporter_port: 3333

--- a/nri-config-generator/integration-tests/testdata/config_with_scrape_timeout.yml
+++ b/nri-config-generator/integration-tests/testdata/config_with_scrape_timeout.yml
@@ -1,0 +1,15 @@
+parent:
+  child:
+    - element1: a
+    - element2: b
+powerdns_url: http://powerdns:8080/api/v1/
+exporter_port: 9120
+api_key: 11111-222222-33333-44444
+scrape_timeout: 10s
+transformations:
+  - ignore_metrics:
+      - prefixes:
+          - kube_daemonset_
+  - ignore_metrics:
+      - prefixes:
+          - kube_daemonset_

--- a/nri-config-generator/integration-tests/testdata/integration_template/nri-powerdns.prometheus.json.tmpl
+++ b/nri-config-generator/integration-tests/testdata/integration_template/nri-powerdns.prometheus.json.tmpl
@@ -27,6 +27,9 @@
                     "version": "{{.integration_version}}",
                     "name": "{{.integration}}"
                 },
+                {{- if .config.scrape_timeout }}
+                "scrape_timeout": "{{.config.scrape_timeout}}",
+                {{ end }}
                 "targets": [
                     {
                         "urls": [

--- a/nri-config-generator/templates/default/config.json.tmpl
+++ b/nri-config-generator/templates/default/config.json.tmpl
@@ -27,6 +27,9 @@
                     "version": "{{.integration_version}}",
                     "name": "{{.integration}}"
                 },
+                {{- if .config.scrape_timeout }}
+                "scrape_timeout": "{{.config.scrape_timeout}}",
+                {{ end }}
                 "targets": [
                     {
                         "urls": [


### PR DESCRIPTION
`scrape_timeout` configuration field is supported for any integration using the default nri-prometheus configuration template. `powerdns` integration version is bumped as well, so it is released once the changes are merged. There are two follow-up PRs (whose base branch should be changed to main once this is merged): #165, #166.