### PR TITLE
NEWRELIC-4959: support scrape_timeout in mongodb3

### DIFF
--- a/exporters/mongodb3/exporter.yml
+++ b/exporters/mongodb3/exporter.yml
@@ -1,7 +1,7 @@
 # name of the exporter, should match with the folder name
 name: mongodb3
 # version of the package created
-version: 0.0.3
+version: 0.0.4
 # Relative path to the License path from the repository root
 exporter_license_path: LICENSE
 # URL to the git project hosting the exporter

--- a/exporters/mongodb3/mongodb3-config.yml.sample
+++ b/exporters/mongodb3/mongodb3-config.yml.sample
@@ -38,10 +38,12 @@ integrations:
         # Port to expose scrape endpoint on, If this is not provided a random port will be used to launch the exporter
         exporter_port: 9126
 
+        # How long until a scrape request times-out (defaults to 5s)
+        # scrape_timeout: 5s
+
         # transformations:
         #   - description: "General processing rules"
         #     ignore_metrics:
         #     - prefixes:
         #       - "go_"
         #       - "process_"
-

--- a/exporters/mongodb3/mongodb3.prometheus.json.tmpl
+++ b/exporters/mongodb3/mongodb3.prometheus.json.tmpl
@@ -28,6 +28,9 @@
                     "version": "{{.integration_version}}",
                     "name": "{{.integration}}"
                 },
+                {{- if .config.scrape_timeout }}
+                "scrape_timeout": "{{.config.scrape_timeout}}",
+                {{ end }}
                 "targets": [
                     {
                         "urls": [


### PR DESCRIPTION
mongodb3's template to configure nri-prometheus is updated and the integration version is bumped so  `scrape_timeout` configuration field is supported for this integration in the same way it is supported for integrations using the default (template #164)