### PR TITLE
chore: Remove unused pipeline code (NR-127868)

### DIFF
--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -42,9 +42,6 @@ if [ "$goos" == "windows" ]; then
     cp "${integration_target}/bin/nri-${NAME}.exe" "${root_dir}/dist/New Relic/newrelic-infra/newrelic-integrations/bin"
     cp "${integration_dir}/${NAME}-win-definition.yml" "${root_dir}/dist/New Relic/newrelic-infra/newrelic-integrations/" || true
 
-    mkdir -p "${root_dir}/dist/New Relic/newrelic-infra/logging.d"
-    cp "${integration_dir}/${NAME}-log-win.yml" "${root_dir}/dist/New Relic/newrelic-infra/logging.d/" || true
-
     (
       # Inside a subshell so we do not change $PWD to the rest of the script
       cd "${root_dir}/dist"


### PR DESCRIPTION
The log files this code copy is not being used by the package pipeline. 
Removing this to avoid confusion.
