### PR TITLE
NR-141099: setup renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,22 +2,31 @@
   "extends": [
     "github>newrelic/coreint-automation:renovate-base.json5"
   ],
+  "suppressNotifications": ["dependencyLookupWarnings"], // expected as some repositories use main and other repositories master
   "regexManagers": [
+    // Updates every exporter commit with the latests in the default branch.
     {
-      // Updates every exporter commit with the latests in the default branch.
       "fileMatch": ["^exporters/.+/exporter.yml$"],
       "matchStringsStrategy": "combination",
       "matchStrings": [
         "exporter_repo_url: (?<packageName>https:\/\/github\.com\/(?<depName>.+))\n",
         "exporter_commit: (?<currentDigest>.+)\n",
-        // currentValue needs to hold the reference in git-refs data sources to update the digest, we use the default
-        // branch from the changelog url.
-        "exporter_changelog: https\:\/\/github\.com.+\/blob\/(?<currentValue>.+)\/",
       ],
+      "currentValueTemplate": "main",
       "datasourceTemplate": "git-refs",
     },
     {
-      // Updates every exporter tag with the latests in the default branch.
+      "fileMatch": ["^exporters/.+/exporter.yml$"],
+      "matchStringsStrategy": "combination",
+      "matchStrings": [
+        "exporter_repo_url: (?<packageName>https:\/\/github\.com\/(?<depName>.+))\n",
+        "exporter_commit: (?<currentDigest>.+)\n",
+      ],
+      "currentValueTemplate": "master",
+      "datasourceTemplate": "git-refs",
+    },
+    // Updates every exporter tag with the latests in the default branch.
+    {
       "fileMatch": ["^exporters/.+/exporter.yml$"],
       "matchStringsStrategy": "combination",
       "matchStrings": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,30 @@
+{
+  "extends": [
+    "github>newrelic/coreint-automation:renovate-base.json5"
+  ],
+  "regexManagers": [
+    {
+      // Updates every exporter commit with the latests in the default branch.
+      "fileMatch": ["^exporters/.+/exporter.yml$"],
+      "matchStringsStrategy": "combination",
+      "matchStrings": [
+        "exporter_repo_url: (?<packageName>https:\/\/github\.com\/(?<depName>.+))\n",
+        "exporter_commit: (?<currentDigest>.+)\n",
+        // currentValue needs to hold the reference in git-refs data sources to update the digest, we use the default
+        // branch from the changelog url.
+        "exporter_changelog: https\:\/\/github\.com.+\/blob\/(?<currentValue>.+)\/",
+      ],
+      "datasourceTemplate": "git-refs",
+    },
+    {
+      // Updates every exporter tag with the latests in the default branch.
+      "fileMatch": ["^exporters/.+/exporter.yml$"],
+      "matchStringsStrategy": "combination",
+      "matchStrings": [
+        "exporter_repo_url: (?<packageName>https:\/\/github\.com\/(?<depName>.+))\n",
+        "exporter_tag: (?<currentValue>.+)\n",
+      ],
+      "datasourceTemplate": "git-refs",
+    }
+  ]
+}

--- a/.github/workflows/nri-config-generator.yml
+++ b/.github/workflows/nri-config-generator.yml
@@ -12,6 +12,9 @@ on:
   pull_request:
     branches: [ main ]
     paths: [ nri-config-generator/** ]
+  push:
+    branches:
+      - renovate/**
 
 jobs:
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,6 +13,9 @@
 on:
   pull_request:
     branches: [ main ]
+  push:
+    branches:
+      - renovate/**
 
 env:
   GPG_MAIL: 'infrastructure-eng@newrelic.com'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,47 @@
+name: Security Scan
+
+on:
+  push:
+    branches:
+      - master
+      - main
+      - renovate/**
+  pull_request:
+  schedule:
+    - cron: "0 3 * * *"
+
+jobs:
+  trivy:
+    name: Trivy security scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@0.7.1
+        if: ${{ ! github.event.schedule }} # Do not run inline checks when running periodically
+        with:
+          scan-type: fs
+          ignore-unfixed: true
+          exit-code: 1
+          severity: 'HIGH,CRITICAL'
+          skip-dirs: 'exporters'
+
+      - name: Run Trivy vulnerability scanner sarif output
+        uses: aquasecurity/trivy-action@0.7.1
+        if: ${{ github.event.schedule }} # Generate sarif when running periodically
+        with:
+          scan-type: fs
+          ignore-unfixed: true
+          severity: 'HIGH,CRITICAL'
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+          skip-dirs: 'exporters'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        if: ${{ github.event.schedule }} # Upload sarif when running periodically
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
It includes the renovate base configuration and adds additional rules to update the exporters by opening a PR.

When reviewing, keeping an `exporter.yml` file handy will help (first lines from ibmmq file below):

```yaml
# name of the exporter, should match with the folder name
name: ibmmq
# version of the package created
version: 0.4.3
# Relative path to the License path from the repository root
exporter_license_path: LICENSE
# URL to the git project hosting the exporter
exporter_repo_url: https://github.com/ibm-messaging/mq-metric-samples
# Tag of the exporter to checkout
exporter_tag:
# Commit of the exporter to checkout (used if tag property is empty)
exporter_commit: 322e8f6cc5ac687e5766acd4eaee447cc7d62d7a
# Changelog to add to the new release
exporter_changelog: https://github.com/ibm-messaging/mq-metric-samples/blob/master/CHANGELOG.md
# ...
```

It has been tested in [this fork](https://github.com/sigilioso/newrelic-prometheus-exporters-packages/issues/2):

<img width="950" alt="image" src="https://github.com/newrelic/newrelic-prometheus-exporters-packages/assets/442627/2cf6ba16-3f54-431d-9b64-7f7735ee6dd4">

