### PR TITLE
Upgrade `mongodb3` version to 3.x

### DIFF
--- a/exporters/mongodb3/exporter.yml
+++ b/exporters/mongodb3/exporter.yml
@@ -1,7 +1,7 @@
 # name of the exporter, should match with the folder name
 name: mongodb3
 # version of the package created
-version: 1.0.0
+version: 3.0.0
 # Relative path to the License path from the repository root
 exporter_license_path: LICENSE
 # URL to the git project hosting the exporter


### PR DESCRIPTION
The rationale for this change is that we can confuse the users in two ways:
 * At documentation level, we can specify that version 2.x and >= 3.x have different configuration paths.
 * At version of the package level, a user might confuse the packages and install version 1.0 for `nri-mongodb` instead of `nri-mongodb3`.