### PR TITLE
chore: Bump nri-ibmmq exporter version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -35,5 +35,14 @@
       ],
       "datasourceTemplate": "git-refs",
     }
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        // Skip updating ibmmq e2e images. Test are not currently running on these PR and some changes brake the tests.
+        "icr.io/ibm-messaging/mq"
+      ],
+      "enabled": false
+    }
   ]
 }

--- a/exporters/ibmmq/build-exporter-windows.sh
+++ b/exporters/ibmmq/build-exporter-windows.sh
@@ -25,8 +25,6 @@ fi
 # ###############################################################
 #  Build exporter
 
-go mod tidy
-
 curl -qsLO "https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/${ibmmq_client_libs_version}-IBM-MQC-Redist-Win64.zip"
 unzip "${ibmmq_client_libs_version}-IBM-MQC-Redist-Win64.zip" -d "IBM-MQC-Redist-Win64"
 export CGO_CFLAGS="-I$(cygpath -aw .)\\IBM-MQC-Redist-Win64\\tools\\c\\include -D_WIN64"

--- a/exporters/ibmmq/build-exporter-windows.sh
+++ b/exporters/ibmmq/build-exporter-windows.sh
@@ -7,7 +7,7 @@ set -euo pipefail -x
 root_dir=$1
 integration_dir="${root_dir}/exporters/ibmmq"
 integration_bin_dir="${integration_dir}/target/bin"
-ibmmq_client_libs_version="9.3.0.1"
+ibmmq_client_libs_version="9.3.4.0"
 
 # ###############################################################
 #  Clone exporter

--- a/exporters/ibmmq/e2e/agent_dir/newrelic-infra-agent/Dockerfile
+++ b/exporters/ibmmq/e2e/agent_dir/newrelic-infra-agent/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir -p /opt/mqm \
 # Location of the downloadable MQ client package \
 ENV RDURL="https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist" \
     RDTAR="IBM-MQC-Redist-LinuxX64.tar.gz" \
-    VRMF=9.2.5.0
+    VRMF=9.3.4.0
 
 # Install the MQ client from the Redistributable package. This also contains the
 # header files we need to compile against. Setup the subset of the package

--- a/exporters/ibmmq/e2e/docker-compose-tls.yml
+++ b/exporters/ibmmq/e2e/docker-compose-tls.yml
@@ -12,6 +12,7 @@ services:
             - MQ_ENABLE_METRICS=true
             - MQ_ENABLE_EMBEDDED_WEB_SERVER=1
             - MQ_APP_PASSWORD=passw0rd
+            - MQ_ADMIN_PASSWORD=passw0rd
             # MQ_DEV generates default objects (qeues, channels, users...) used for the test.
             # More details in https://github.com/ibm-messaging/mq-container/blob/master/docs/developer-config.md
         entrypoint: [ "/bin/bash", "-c", "/usr/local/bin/entrypoint-server-tls.sh" ]

--- a/exporters/ibmmq/e2e/docker-compose-tls.yml
+++ b/exporters/ibmmq/e2e/docker-compose-tls.yml
@@ -5,7 +5,7 @@ services:
         platform: linux/x86_64
         # We need to re-generate testing certificates before upgrading it because queue manager certificates
         # with the same DN as the CA are not supported anymore. See: <https://github.com/ibm-messaging/mq-container/blob/master/CHANGELOG.md#9320-2023-02>
-        image: icr.io/ibm-messaging/mq:9.3.3.2-r2
+        image: icr.io/ibm-messaging/mq:9.3.1.0-r2
         environment:
             - LICENSE=accept
             - MQ_QMGR_NAME=QM1

--- a/exporters/ibmmq/e2e/docker-compose.yml
+++ b/exporters/ibmmq/e2e/docker-compose.yml
@@ -13,6 +13,7 @@ services:
             # More details in https://github.com/ibm-messaging/mq-container/blob/master/docs/developer-config.md
             - MQ_DEV=true
             - MQ_APP_PASSWORD=passw0rd
+            - MQ_ADMIN_PASSWORD=passw0rd
         ports:
             - "9443:9443"
             - "1414:1414"

--- a/exporters/ibmmq/exporter.yml
+++ b/exporters/ibmmq/exporter.yml
@@ -1,7 +1,7 @@
 # name of the exporter, should match with the folder name
 name: ibmmq
 # version of the package created
-version: 0.4.3
+version: 0.5.0
 # Relative path to the License path from the repository root
 exporter_license_path: LICENSE
 # URL to the git project hosting the exporter
@@ -9,7 +9,8 @@ exporter_repo_url: https://github.com/ibm-messaging/mq-metric-samples
 # Tag of the exporter to checkout
 exporter_tag:
 # Commit of the exporter to checkout (used if tag property is empty)
-exporter_commit: 322e8f6cc5ac687e5766acd4eaee447cc7d62d7a
+# Tag v5.5.2
+exporter_commit: d43cd78aac134aac04c407f58b58820527ebdcaf
 # Changelog to add to the new release
 exporter_changelog: https://github.com/ibm-messaging/mq-metric-samples/blob/master/CHANGELOG.md
 # Enable packages for Linux

--- a/exporters/ibmmq/readme.md
+++ b/exporters/ibmmq/readme.md
@@ -1,0 +1,5 @@
+# Bump exporter runbook 
+- Update commit in exporter.yml
+- Update client library version
+  - Update 'ibmmq_client_libs_version' in build-exporter-windows.sh. Use the same as the on [used](https://github.com/ibm-messaging/mq-metric-samples/blob/master/Dockerfile.build#L64) to build Linux 
+  - Update client library version in the [e2e test](./e2e/agent_dir/newrelic-infra-agent/Dockerfile)


### PR DESCRIPTION
Using [latest tag](https://github.com/ibm-messaging/mq-metric-samples/releases/tag/v5.5.2) of the exporter and bumping the client library for windows to the same version as the one [used](https://github.com/ibm-messaging/mq-metric-samples/blob/master/Dockerfile.build#L64) in Linux builds