### PR TITLE
chore: increase proposed scrape_timeout

### DIFF
--- a/exporters/mongodb3/exporter.yml
+++ b/exporters/mongodb3/exporter.yml
@@ -1,7 +1,7 @@
 # name of the exporter, should match with the folder name
 name: mongodb3
 # version of the package created
-version: 3.1.0
+version: 3.1.1
 # Relative path to the License path from the repository root
 exporter_license_path: LICENSE
 # URL to the git project hosting the exporter

--- a/exporters/mongodb3/mongodb3-config.yml.sample
+++ b/exporters/mongodb3/mongodb3-config.yml.sample
@@ -38,8 +38,8 @@ integrations:
         # Port to expose scrape endpoint on, If this is not provided a random port will be used to launch the exporter
         exporter_port: 9126
 
-        # How long until a scrape request times-out (defaults to 5s)
-        # scrape_timeout: 5s
+        # How long until a scrape request times-out. If not provided the default timeout is 5s
+        scrape_timeout: 30s
 
         # transformations:
         #   - description: "General processing rules"


### PR DESCRIPTION
Hoping to reduce the chances to get into [this issue](https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration-new/#prometheus-timeout) this PR increments the  proposed default value for the `nri-prometheus` `scrape_timeout` to the same default value of the integration default interval.