### PR TITLE
fix: use NRI_CONFIG_INTERVAL env var (NR-248457)

### DIFF
--- a/exporters/mongodb3/exporter.yml
+++ b/exporters/mongodb3/exporter.yml
@@ -1,15 +1,16 @@
 # name of the exporter, should match with the folder name
 name: mongodb3
 # version of the package created
-version: 3.1.1
+version: 3.1.2
 # Relative path to the License path from the repository root
 exporter_license_path: LICENSE
 # URL to the git project hosting the exporter
 exporter_repo_url: https://github.com/percona/mongodb_exporter
 # Tag of the exporter to checkout
-exporter_tag: v0.40.0
+exporter_tag:
 # Commit of the exporter to checkout (used if tag property is empty)
-exporter_commit:
+# commit for v0.40.0 tag
+exporter_commit: cb3db8922fb068bba6ecd4c12c231cb63d970515
 # Changelog to add to the new release
 exporter_changelog: https://github.com/percona/mongodb_exporter/blob/main/CHANGELOG
 # Enable packages for Linux

--- a/exporters/mongodb3/mongodb3.prometheus.json.tmpl
+++ b/exporters/mongodb3/mongodb3.prometheus.json.tmpl
@@ -7,8 +7,8 @@
     "integrations": [
          {
             "name": "nri-prometheus",
-            {{- if .env.interval }}
-            "interval": "{{.env.interval}}",
+            {{- if .env.NRI_CONFIG_INTERVAL }}
+            "interval": "{{.env.NRI_CONFIG_INTERVAL}}",
             {{ end }}
             "config": {
                 "standalone": false,

--- a/nri-config-generator/integration-tests/generator_test.go
+++ b/nri-config-generator/integration-tests/generator_test.go
@@ -143,10 +143,10 @@ func TestGeneratorConfigPortAlreadyInUse(t *testing.T) {
 	assert.JSONEq(t, expectedResponse, string(stdout))
 }
 
-// The env var interval is provided
+// The env var interval is provided by the Agent and used to set the prometheus scrape interval.
 func TestGeneratorConfigWithInterval(t *testing.T) {
 	envVars := getConfigGeneratorEnvVars("config.yml")
-	envVars = append(envVars, "interval=10s")
+	envVars = append(envVars, "NRI_CONFIG_INTERVAL=10s")
 	stdout, err := callGeneratorConfig(defaultArgs, envVars)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, stdout)

--- a/nri-config-generator/integration-tests/testdata/integration_template/nri-powerdns.prometheus.json.tmpl
+++ b/nri-config-generator/integration-tests/testdata/integration_template/nri-powerdns.prometheus.json.tmpl
@@ -7,8 +7,8 @@
     "integrations": [
          {
             "name": "nri-prometheus",
-            {{- if .env.interval }}
-            "interval": "{{.env.interval}}",
+            {{- if .env.NRI_CONFIG_INTERVAL }}
+            "interval": "{{.env.NRI_CONFIG_INTERVAL}}",
             {{ end }}
             "config": {
                 "standalone": false,

--- a/nri-config-generator/templates/default/config.json.tmpl
+++ b/nri-config-generator/templates/default/config.json.tmpl
@@ -7,8 +7,8 @@
     "integrations": [
          {
             "name": "nri-prometheus",
-            {{- if .env.interval }}
-            "interval": "{{.env.interval}}",
+            {{- if .env.NRI_CONFIG_INTERVAL }}
+            "interval": "{{.env.NRI_CONFIG_INTERVAL}}",
             {{ end }}
             "config": {
                 "standalone": false,


### PR DESCRIPTION
The interval configuration mechanism for the prometheus exporter based integrations relies on the Env var `NRI_CONFIG_INTERVAL` populated by the Agent.

The current mappings are not using it , instead they are pointing to `interval` which is a env var that do not exists. 

This pr change the correct env var for the default template and the mongodb one which is using a custom one.

A following PR have to be don to releease ibmmq so the change is applied. 