### PR TITLE
Added patch to go version in the go.mod file

### DIFF
--- a/nri-config-generator/go.mod
+++ b/nri-config-generator/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/nri-config-generator
 
-go 1.23
+go 1.23.2
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0


### PR DESCRIPTION
Added patch to the GoLang versions in `nri-config-generator/go.mod` file to ensure Renovate Auto merges PRs whenever a new GoLang patch version is released.