### PR TITLE
fix: accept env vars in mongodb3 exporter

### DIFF
--- a/exporters/mongodb3/mongodb3-config.yml.sample
+++ b/exporters/mongodb3/mongodb3-config.yml.sample
@@ -47,3 +47,8 @@ integrations:
         #     - prefixes:
         #       - "go_"
         #       - "process_"
+
+        # The following parameters will be passed as environment variables directly to the mongodb exporter
+
+        # MONGODB_URI environment variable for the MongoDB connection URI used by the exporter.
+        # mongodb_uri: mongodb://user:pass@localhost:27017

--- a/exporters/mongodb3/mongodb3.json.tmpl
+++ b/exporters/mongodb3/mongodb3.json.tmpl
@@ -2,11 +2,6 @@
     "exec": [
         "{{ .exporter_binary_path }}",
 
-        {{ if .config.mongodb_uri}}
-        "--mongodb.uri",
-        "{{.config.mongodb_uri}}",
-        {{end}}
-
         {{ if .config.collection_filters}}
         "--mongodb.collstats-colls",
         "{{.config.collection_filters}}",
@@ -55,4 +50,10 @@
         "--web.listen-address",
         ":{{.exporter_port}}",
     ],
+
+    {{- if or .config.mongodb_uri .env.MONGODB_URI }}
+    "env": {
+        "MONGODB_URI": "{{ if .config.mongodb_uri }}{{ .config.mongodb_uri }}{{ else }}{{ .env.MONGODB_URI }}{{ end }}"
+    }
+    {{- end }}
 }


### PR DESCRIPTION
- Update mongodb template to accept `MONGODB_URI` env var
- Update mongodb config.yml sample

**Validation Results**

> infra-agent subprocesses:
<img width="1602" alt="Screenshot 2025-05-21 at 5 55 33 PM" src="https://github.com/user-attachments/assets/a7099551-7aed-4f8d-b8b2-09809d3fd8ad" />


> ps -ef | grep mongo
<img width="1652" alt="Screenshot 2025-05-21 at 5 56 06 PM" src="https://github.com/user-attachments/assets/614a0e9b-51ba-492d-a1ca-f988172ca234" />

>NR dashboard
<img width="1629" alt="Screenshot 2025-05-21 at 5 54 55 PM" src="https://github.com/user-attachments/assets/04bdb1b2-eca4-44d7-a79d-b59f8ff499f9" />


