### PR TITLE
security: add permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,9 @@ on:
         description: 'Name of the exporter to run e2e'
         required: true
 
+permissions:
+  contents: read
+
 env:
   GORELEASER_VERSION: 'v1.13.1'
 

--- a/.github/workflows/manual-artifacts-generation.yml
+++ b/.github/workflows/manual-artifacts-generation.yml
@@ -6,6 +6,10 @@ on:
         required: true
         default: 'powerdns'
         type: string
+
+permissions:
+  contents: read
+
 env:
   OHAI_PFX_CERTIFICATE_BASE64: ${{ secrets.OHAI_PFX_CERTIFICATE_BASE64 }} # base64 encoded
   OHAI_PFX_PASSPHRASE:  ${{ secrets.OHAI_PFX_PASSPHRASE }}

--- a/.github/workflows/nri-config-generator.yml
+++ b/.github/workflows/nri-config-generator.yml
@@ -16,6 +16,9 @@ on:
     branches:
       - renovate/**
 
+permissions:
+  contents: read
+
 jobs:
 
   # TODO use https://github.com/newrelic/newrelic-infra-checkers

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,6 +17,9 @@ on:
     branches:
       - renovate/**
 
+permissions:
+  contents: read
+
 env:
   GPG_MAIL: 'infrastructure-eng@newrelic.com'
   OHAI_PFX_CERTIFICATE_BASE64: ${{ secrets.OHAI_PFX_CERTIFICATE_BASE64 }} # base64 encoded

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
   release:
     types: [released]
 
+permissions:
+  contents: read
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   ORIGINAL_REPO_NAME: ${{ github.event.repository.full_name }}

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -6,6 +6,9 @@ on:
   push:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   repolinter:
     uses: newrelic/coreint-automation/.github/workflows/reusable_repolinter.yaml@v2

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: "0 3 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   security:
     uses: newrelic/coreint-automation/.github/workflows/reusable_security.yaml@v3


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to all workflow files missing a permissions block
- Follows the principle of least privilege for GitHub Actions tokens
- Resolves CodeQL alert `actions/missing-workflow-permissions` ([NR-560248](https://new-relic.atlassian.net/browse/NR-560248))

## Test plan
- [ ] Verify CI workflows still pass with the new permissions block
- [ ] Confirm CodeQL alert is resolved after merge

[NR-560248]: https://new-relic.atlassian.net/browse/NR-560248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ